### PR TITLE
Fix dark theme filters and job cards in admin panel

### DIFF
--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -32,67 +32,24 @@ const $chips = document.querySelectorAll("#chip-categories .chip");
 const $search = document.getElementById("search-input");
 const $navItems = document.querySelectorAll(".nav-item");
 
-const CATEGORY_ALIASES = {
-  mobile_app: { base: "web", label: "Desarrollo App Móvil" },
-  desktop_app: { base: "automations", label: "Desarrollo App escritorio" }
-};
-
 const CATEGORY_LABELS = {
-  web: "Web",
+  web: "Páginas web",
   automations: "Automatizaciones",
-  support: "Soporte",
-  maintenance: "Mantenimiento",
-  mobile_app: CATEGORY_ALIASES.mobile_app.label,
-  desktop_app: CATEGORY_ALIASES.desktop_app.label
+  support: "Soportes",
+  maintenance: "Mantenimientos",
+  mobile_app: "Desarrollo App Móvil",
+  desktop_app: "Desarrollo App escritorio"
 };
-
-function normalizeCategoryValue(value){
-  const key = (value || "").trim();
-  return CATEGORY_ALIASES[key]?.base || key;
-}
-
-function stripCategoryOverride(desc){
-  return (desc || "").replace(/\n?\[cat_override=[^\]]+\]\s*$/i, "").trimEnd();
-}
-
-function encodeCategoryOverride(desc, value){
-  const clean = stripCategoryOverride(desc);
-  if(CATEGORY_ALIASES[value]){
-    return `${clean}${clean ? "\n\n" : ""}[cat_override=${value}]`;
-  }
-  return clean;
-}
-
-function readCategoryOverride(desc){
-  const match = (desc || "").match(/\[cat_override=([a-z0-9_]+)\]/i);
-  const val = match ? match[1] : null;
-  return val && CATEGORY_ALIASES[val] ? val : null;
-}
 
 function catLabel(key){
   return CATEGORY_LABELS[key] || key;
 }
 
-async function resolveCategoryOverrides(rows){
-  const map = {};
-  const aliasBases = new Set(Object.values(CATEGORY_ALIASES).map(v=>v.base));
-  const pending = [];
-  (rows||[]).forEach(r=>{
-    const fromRow = readCategoryOverride(r?.description || "");
-    if(fromRow){
-      map[r.id] = fromRow;
-    }else if(aliasBases.has(r.category)){ pending.push(r.id); }
-  });
-  const uniquePending = [...new Set(pending.filter(id=> !map[id]))];
-  if(!uniquePending.length) return map;
-  try{
-    const { data } = await sb.from('jobs').select('id,description').in('id', uniquePending);
-    (data||[]).forEach(job=>{
-      const override = readCategoryOverride(job?.description || "");
-      if(override) map[job.id] = override;
-    });
-  }catch(e){}
-  return map;
+const MANAGER_ROLES = new Set(["CEO", "Administrador"]);
+const DEFAULT_ROLE = "Tecnico";
+
+function isManager(role){
+  return MANAGER_ROLES.has(role);
 }
 
 
@@ -198,7 +155,7 @@ if($forms.signup){
     const full_name = document.getElementById('signup-name').value.trim();
     const email = document.getElementById('signup-email').value.trim();
     const password = document.getElementById('signup-password').value;
-    const role = document.getElementById('signup-role').value || 'Empleado';
+    const role = document.getElementById('signup-role').value || DEFAULT_ROLE;
     const { data, error } = await sb.auth.signUp({ email, password });
     if(error){ hideLoading(); toast(error.message,'error'); return; }
     try{
@@ -278,7 +235,11 @@ async function boot(){
   try{ setupBrandUI(); await updateBrandValues(); }catch(e){}
   const displayName = (user.user_metadata && (user.user_metadata.full_name || user.user_metadata.name)) || me.full_name || user.email;
   if($userName) $userName.textContent = displayName;
-  if($role){ $role.textContent = me.role?.toUpperCase() || ''; $role.classList.toggle('admin', me.role === 'Administrador'); }
+  if($role){
+    const roleDisplay = me.role || '';
+    $role.textContent = roleDisplay;
+    $role.classList.toggle('admin', isManager(roleDisplay));
+  }
   if($tenure){
     const reg = (user && user.created_at) || (me && me.created_at);
     const t = formatTenure(reg);
@@ -311,7 +272,7 @@ async function ensureProfile(){
   const { data } = await sb.from("profiles").select("id").eq("id", user.id).maybeSingle();
   if(!data){
     const full_name = (user.user_metadata && (user.user_metadata.full_name || user.user_metadata.name)) || null;
-    await sb.from("profiles").insert({ id:user.id, full_name, role:"Empleado" });
+    await sb.from("profiles").insert({ id:user.id, full_name, role: DEFAULT_ROLE });
   }
 }
 async function getMe(){
@@ -374,10 +335,10 @@ async function loadMyUpcoming(){
 async function loadOverdue(){
   const box = document.getElementById('w-overdue'); if(!box) return;
   box.innerHTML = '<li class="meta">Cargando…</li>';
-  const me = await getMe(); const isAdmin = me && me.role==='Administrador';
+  const me = await getMe(); const manager = me && isManager(me.role);
   const { data: tasks, error } = await sb.from('tasks').select('id,job_id,title,status,progress,assignee').neq('status','done');
   if(error){ box.innerHTML = `<li class="meta">${error.message}</li>`; return; }
-  const filtered = (tasks||[]).filter(t=> isAdmin || t.assignee===me.id);
+  const filtered = (tasks||[]).filter(t=> manager || t.assignee===me.id);
   const jobIds = [...new Set(filtered.map(t=>t.job_id).filter(Boolean))];
   let jobsMap = {};
   if(jobIds.length){ const { data: jobs } = await sb.from('jobs').select('id,due_at').in('id', jobIds); (jobs||[]).forEach(j=> jobsMap[j.id]=j); }
@@ -453,27 +414,21 @@ function statusLabel(st){
 async function loadJobs(){
   const requested = filter.cat;
   let q = sb.from("jobs_view").select("*").neq("status","archived");
-  if(requested!=="all") q = q.eq("category", normalizeCategoryValue(requested));
+  if(requested!=="all") q = q.eq("category", requested);
   if(filter.q) q = q.ilike("search_text", `%${filter.q}%`);
   const { data, error } = await q.order("created_at",{ ascending:false });
   if(error){ toast(error.message,"error"); return; }
 
-  const overrideMap = await resolveCategoryOverrides(data);
-  const enriched = (data||[]).map(j=>{
-    const override = overrideMap[j.id];
-    return { ...j, _categoryDisplay: override || j.category };
-  });
-
-  const filteredRows = enriched.filter(j=>{
+  const rows = (data||[]).filter(j=>{
     if(requested === "all") return true;
-    return j._categoryDisplay === requested;
+    return j.category === requested;
   });
 
-  $grid.innerHTML = filteredRows.map(j=>`
+  $grid.innerHTML = rows.map(j=>`
     <article class="job" data-id="${j.id}" style="${statusColor(j.status)}">
       <div class="row">
         <div class="title">${j.title}</div>
-        <div class="tags"><span class="pill">${catPill(j._categoryDisplay)}</span></div>
+        <div class="tags"><span class="pill">${catPill(j.category)}</span></div>
       </div>
       <div class="subrow"><span class="pill st-${j.status}">${statusLabel(j.status)}</span></div>
       <div class="row">
@@ -487,7 +442,7 @@ async function loadJobs(){
   document.querySelectorAll(".job").forEach(el=>{
     el.onclick = async ()=>{
       currentJob = el.dataset.id;
-      const job = enriched.find(x=>x.id===currentJob);
+      const job = (data||[]).find(x=>x.id===currentJob);
       if(job) document.getElementById("kanban-title").textContent = job.title;
       document.querySelectorAll('.job').forEach(n=> n.classList.remove('selected'));
       el.classList.add('selected');
@@ -527,8 +482,8 @@ async function loadKanban(){
   let rows = data || [];
   try{
     const me = await getMe();
-    const isAdmin = me && me.role === 'Administrador';
-    if(!isAdmin){
+    const privileged = me && isManager(me.role);
+    if(!privileged){
       rows = rows.filter(t=> t.assignee && t.assignee === me.id);
     }
   }catch(e){}
@@ -676,13 +631,12 @@ function enhanceUI(){
       if(error){ toast(error.message,'error'); return; }
       document.getElementById('edit-job-id').value = data.id;
       document.getElementById('edit-job-title').value = data.title||'';
-      const override = readCategoryOverride(data.description || '');
-      document.getElementById('edit-job-category').value = override || data.category || 'web';
+      document.getElementById('edit-job-category').value = data.category || 'web';
       document.getElementById('edit-job-status').value = data.status||'in_progress';
       document.getElementById('edit-job-progress').value = Number(data.progress||0);
       document.getElementById('edit-job-start').value = data.start_at ? new Date(data.start_at).toISOString().slice(0,16) : '';
       document.getElementById('edit-job-due').value = data.due_at ? new Date(data.due_at).toISOString().slice(0,16) : '';
-      document.getElementById('edit-job-desc').value = stripCategoryOverride(data.description || '');
+      document.getElementById('edit-job-desc').value = data.description || '';
       openDialog(modalEditJob);
     };
   }
@@ -693,12 +647,12 @@ function enhanceUI(){
       const descValue = document.getElementById('edit-job-desc').value;
       const payload = {
         title: document.getElementById('edit-job-title').value.trim(),
-        category: normalizeCategoryValue(selectedCat),
+        category: selectedCat,
         status: document.getElementById('edit-job-status').value,
         progress: Number(document.getElementById('edit-job-progress').value||0),
         start_at: document.getElementById('edit-job-start').value || null,
         due_at: document.getElementById('edit-job-due').value || null,
-        description: encodeCategoryOverride(descValue.trim(), selectedCat)
+        description: descValue.trim()
       };
       if(!payload.title){ toast('Título requerido','error'); return; }
       const { error } = await sb.from('jobs').update(payload).eq('id', id);
@@ -837,12 +791,11 @@ document.getElementById("btn-save-job").onclick = async ()=>{
   const obj = {
     client_id: document.getElementById("job-client").value || null,
     title: document.getElementById("job-title").value.trim(),
-    category: normalizeCategoryValue(selectedCat),
-    description: encodeCategoryOverride(descriptionInput.trim(), selectedCat),
+    category: selectedCat,
+    description: descriptionInput.trim(),
     start_at: document.getElementById("job-start").value || null,
     due_at: document.getElementById("job-due").value || null
   };
-  if(!obj.title){ toast("Título requerido","error"); return; }
   if(!obj.title){ toast("Título requerido","error"); return; }
   const { error } = await sb.from("jobs").insert(obj);
   if(error){ toast(error.message,"error"); return; }
@@ -870,30 +823,38 @@ async function loadUsersIntoSelect(){
   if(!sel) return;
   let me = null;
   try{ me = await getMe(); }catch(e){}
-  const isAdmin = me && me.role === 'Administrador';
+  const manager = me && isManager(me.role);
   let users = [];
   try{
-    // Primer intento: según rol
-    let q = sb.from("profiles").select("id,full_name,role").order("full_name");
-    if(isAdmin){ q = q.in("role", ["Empleado","Administrador"]); }
-    else { q = q.eq("role","Empleado"); }
-    let { data, error } = await q;
-    if(error) throw error;
-    users = data || [];
-    // Fallback si viene vacío: relajamos filtro
-    if(!users.length){
-      const res = await sb.from("profiles").select("id,full_name,role").order("full_name");
-      users = (res.data || []).filter(u=> isAdmin ? true : (u.role !== 'Administrador'));
+    if(manager){
+      const { data, error } = await sb.from("profiles").select("id,full_name,role").order("full_name");
+      if(error) throw error;
+      users = data || [];
+    }else{
+      const managerRoles = Array.from(MANAGER_ROLES);
+      const list = [];
+      if(me) list.push(me);
+      const { data: admins, error } = await sb.from("profiles")
+        .select("id,full_name,role")
+        .in("role", managerRoles)
+        .order("full_name");
+      if(error) throw error;
+      (admins || []).forEach(u=> list.push(u));
+      const unique = new Map();
+      list.forEach(u=>{ if(u && u.id && !unique.has(u.id)) unique.set(u.id, u); });
+      users = Array.from(unique.values()).sort((a,b)=>{
+        const nameA = a.full_name || '';
+        const nameB = b.full_name || '';
+        return nameA.localeCompare(nameB, 'es', { sensitivity:'base' });
+      });
     }
   }catch(e){ users = []; }
 
-  if(!users.length){
-    sel.innerHTML = `<option value="">— Sin asignar —</option>`;
-    return;
-  }
-  sel.innerHTML = `<option value="">— Sin asignar —</option>` + users
-    .map(u=>`<option value="${u.id}">${u.full_name || u.id} (${u.role || ''})</option>`)
-    .join("");
+  const options = [`<option value="">— Sin asignar —</option>`];
+  users.forEach(u=>{
+    options.push(`<option value="${u.id}">${u.full_name || u.id} (${u.role || ''})</option>`);
+  });
+  sel.innerHTML = options.join("");
 }
 document.getElementById("btn-save-task").onclick = async ()=>{
   const obj = {
@@ -903,7 +864,6 @@ document.getElementById("btn-save-task").onclick = async ()=>{
     status: document.getElementById("task-status").value,
     progress: Number(document.getElementById("task-progress").value || 0)
   };
-  if(!obj.title){ toast("Título requerido","error"); return; }
   if(!obj.title){ toast("Título requerido","error"); return; }
   const { error } = await sb.from("tasks").insert(obj);
   if(error){ toast(error.message,"error"); return; }
@@ -1020,14 +980,9 @@ async function loadJobsTable(){
   const tbody = document.getElementById("jobs-tbody");
   if(!tbody) return;
   const q = (document.getElementById('jobs-search')?.value || '').toLowerCase();
-  const overrideMap = await resolveCategoryOverrides(data);
-  const enriched = (data||[]).map(j=>{
-    const override = overrideMap[j.id];
-    return { ...j, _categoryDisplay: override || j.category };
-  });
-  const rows = enriched.filter(j=>{
+  const rows = (data||[]).filter(j=>{
     if(!q) return true;
-    return [j.title, j.client_name, j._categoryDisplay, j.status].join(' ').toLowerCase().includes(q);
+    return [j.title, j.client_name, j.category, j.status].join(' ').toLowerCase().includes(q);
   }).map(j=>{
     const statusLabel = ({ done:"Completado", on_hold:"Pausado", in_progress:"En progreso" })[j.status] || j.status;
     const eta = j.due_at ? dayjs(j.due_at).format('DD/MM HH:mm') : '';
@@ -1035,7 +990,7 @@ async function loadJobsTable(){
       <tr>
         <td>${j.title}</td>
         <td>${j.client_name||""}</td>
-        <td>${catPill(j._categoryDisplay)}</td>
+        <td>${catPill(j.category)}</td>
         <td><span class="pill">${statusLabel}</span></td>
         <td class="progress-cell"><div class="progress"><span style="width:${j.progress||0}%"></span></div></td>
         <td>${eta}</td>
@@ -1058,28 +1013,42 @@ async function loadUsersList(){
   const hint = document.getElementById('users-hint');
   if(!tbody) return;
   const me = await getMe();
-  const isAdmin = me && me.role === 'Administrador';
-  if(!isAdmin){
-    // Mostrar solo tu propio perfil
-    const one = me ? [me] : [];
-    tbody.innerHTML = one.map(u=>`
-      <tr>
-        <td>${u.full_name||''}</td>
-        <td>${u.role||''}</td>
-        <td>${u.numero_telefono||''}</td>
-        <td>${u.created_at ? dayjs(u.created_at).format('DD/MM/YYYY HH:mm') : ''}</td>
-      </tr>
-    `).join('');
-    if(hint) hint.textContent = 'Solo los administradores pueden ver todos los usuarios.';
-    return;
-  }
-  // Admin: listar todos
-  const { data, error } = await sb.from('profiles').select('full_name,role,numero_telefono,created_at').order('created_at',{ascending:false});
-  if(error){ tbody.innerHTML=''; if(hint) hint.textContent = error.message; return; }
+  const manager = me && isManager(me.role);
   const q = (document.getElementById('users-search')?.value || '').toLowerCase();
-  const rows = (data||[]).filter(u=>{
+  let records = [];
+  let hintMsg = '';
+  if(manager){
+    const { data, error } = await sb
+      .from('profiles')
+      .select('full_name,role,numero_telefono,created_at')
+      .order('created_at',{ascending:false});
+    if(error){ tbody.innerHTML=''; if(hint) hint.textContent = error.message; return; }
+    records = data || [];
+  }else{
+    const unique = new Map();
+    if(me && me.id){ unique.set(me.id, me); }
+    try{
+      const { data: managers, error } = await sb
+        .from('profiles')
+        .select('id,full_name,role,numero_telefono,created_at')
+        .in('role', Array.from(MANAGER_ROLES))
+        .order('created_at',{ascending:false});
+      if(error) throw error;
+      (managers || []).forEach(u=>{ if(u && u.id && !unique.has(u.id)) unique.set(u.id, u); });
+    }catch(e){ hintMsg = e.message || ''; }
+    records = Array.from(unique.values());
+    if(!hintMsg) hintMsg = 'Solo los administradores y CEO pueden ver todos los usuarios.';
+  }
+
+  records = (records || []).slice().sort((a,b)=>{
+    const aDate = a && a.created_at ? new Date(a.created_at).getTime() : 0;
+    const bDate = b && b.created_at ? new Date(b.created_at).getTime() : 0;
+    return bDate - aDate;
+  });
+
+  const rows = records.filter(u=>{
     if(!q) return true;
-    return [u.full_name,u.role,u.numero_telefono].join(' ').toLowerCase().includes(q);
+    return [u.full_name||'', u.role||'', u.numero_telefono||''].join(' ').toLowerCase().includes(q);
   }).map(u=>`
     <tr>
       <td>${u.full_name||''}</td>
@@ -1089,7 +1058,7 @@ async function loadUsersList(){
     </tr>
   `).join('');
   tbody.innerHTML = rows;
-  if(hint) hint.textContent = '';
+  if(hint) hint.textContent = hintMsg;
 }
 
 const $usersSearch = document.getElementById('users-search');

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -32,6 +32,69 @@ const $chips = document.querySelectorAll("#chip-categories .chip");
 const $search = document.getElementById("search-input");
 const $navItems = document.querySelectorAll(".nav-item");
 
+const CATEGORY_ALIASES = {
+  mobile_app: { base: "web", label: "Desarrollo App Móvil" },
+  desktop_app: { base: "automations", label: "Desarrollo App escritorio" }
+};
+
+const CATEGORY_LABELS = {
+  web: "Web",
+  automations: "Automatizaciones",
+  support: "Soporte",
+  maintenance: "Mantenimiento",
+  mobile_app: CATEGORY_ALIASES.mobile_app.label,
+  desktop_app: CATEGORY_ALIASES.desktop_app.label
+};
+
+function normalizeCategoryValue(value){
+  const key = (value || "").trim();
+  return CATEGORY_ALIASES[key]?.base || key;
+}
+
+function stripCategoryOverride(desc){
+  return (desc || "").replace(/\n?\[cat_override=[^\]]+\]\s*$/i, "").trimEnd();
+}
+
+function encodeCategoryOverride(desc, value){
+  const clean = stripCategoryOverride(desc);
+  if(CATEGORY_ALIASES[value]){
+    return `${clean}${clean ? "\n\n" : ""}[cat_override=${value}]`;
+  }
+  return clean;
+}
+
+function readCategoryOverride(desc){
+  const match = (desc || "").match(/\[cat_override=([a-z0-9_]+)\]/i);
+  const val = match ? match[1] : null;
+  return val && CATEGORY_ALIASES[val] ? val : null;
+}
+
+function catLabel(key){
+  return CATEGORY_LABELS[key] || key;
+}
+
+async function resolveCategoryOverrides(rows){
+  const map = {};
+  const aliasBases = new Set(Object.values(CATEGORY_ALIASES).map(v=>v.base));
+  const pending = [];
+  (rows||[]).forEach(r=>{
+    const fromRow = readCategoryOverride(r?.description || "");
+    if(fromRow){
+      map[r.id] = fromRow;
+    }else if(aliasBases.has(r.category)){ pending.push(r.id); }
+  });
+  const uniquePending = [...new Set(pending.filter(id=> !map[id]))];
+  if(!uniquePending.length) return map;
+  try{
+    const { data } = await sb.from('jobs').select('id,description').in('id', uniquePending);
+    (data||[]).forEach(job=>{
+      const override = readCategoryOverride(job?.description || "");
+      if(override) map[job.id] = override;
+    });
+  }catch(e){}
+  return map;
+}
+
 
 // Tenure helpers
 function pad2(n){ return String(Math.max(0, n)).padStart(2,'0'); }
@@ -377,14 +440,7 @@ $search.oninput = ()=>{ filter.q = $search.value.trim(); loadJobs(); };
 // ---------- Jobs grid ----------
 let currentJob = null;
 function catPill(cat){
-  return {
-    web: "Web",
-    automations: "Automatizaciones",
-    support: "Soporte",
-    maintenance: "Mantenimiento",
-    mobile_app: "Desarrollo App Móvil",
-    desktop_app: "Desarrollo App escritorio",
-  }[cat] || cat;
+  return catLabel(cat);
 }
 function statusColor(st){
   return st==="done" ? "border-color:#16a34a" : st==="on_hold" ? "border-color:#eab308" :
@@ -395,17 +451,29 @@ function statusLabel(st){
 }
 
 async function loadJobs(){
+  const requested = filter.cat;
   let q = sb.from("jobs_view").select("*").neq("status","archived");
-  if(filter.cat!=="all") q = q.eq("category", filter.cat);
+  if(requested!=="all") q = q.eq("category", normalizeCategoryValue(requested));
   if(filter.q) q = q.ilike("search_text", `%${filter.q}%`);
   const { data, error } = await q.order("created_at",{ ascending:false });
   if(error){ toast(error.message,"error"); return; }
 
-  $grid.innerHTML = (data||[]).map(j=>`
+  const overrideMap = await resolveCategoryOverrides(data);
+  const enriched = (data||[]).map(j=>{
+    const override = overrideMap[j.id];
+    return { ...j, _categoryDisplay: override || j.category };
+  });
+
+  const filteredRows = enriched.filter(j=>{
+    if(requested === "all") return true;
+    return j._categoryDisplay === requested;
+  });
+
+  $grid.innerHTML = filteredRows.map(j=>`
     <article class="job" data-id="${j.id}" style="${statusColor(j.status)}">
       <div class="row">
         <div class="title">${j.title}</div>
-        <div class="tags"><span class="pill">${catPill(j.category)}</span></div>
+        <div class="tags"><span class="pill">${catPill(j._categoryDisplay)}</span></div>
       </div>
       <div class="subrow"><span class="pill st-${j.status}">${statusLabel(j.status)}</span></div>
       <div class="row">
@@ -419,16 +487,14 @@ async function loadJobs(){
   document.querySelectorAll(".job").forEach(el=>{
     el.onclick = async ()=>{
       currentJob = el.dataset.id;
-      const job = data.find(x=>x.id===currentJob);
-      document.getElementById("kanban-title").textContent = job.title;
-      // Marcar selección visual
+      const job = enriched.find(x=>x.id===currentJob);
+      if(job) document.getElementById("kanban-title").textContent = job.title;
       document.querySelectorAll('.job').forEach(n=> n.classList.remove('selected'));
       el.classList.add('selected');
       await loadKanban();
       await loadJobProgressChart();
     };
   });
-  // Restaurar selección si ya hay un trabajo activo
   if(currentJob){
     const sel = document.querySelector(`.job[data-id="${currentJob}"]`);
     if(sel) sel.classList.add('selected');
@@ -610,26 +676,29 @@ function enhanceUI(){
       if(error){ toast(error.message,'error'); return; }
       document.getElementById('edit-job-id').value = data.id;
       document.getElementById('edit-job-title').value = data.title||'';
-      document.getElementById('edit-job-category').value = data.category||'web';
+      const override = readCategoryOverride(data.description || '');
+      document.getElementById('edit-job-category').value = override || data.category || 'web';
       document.getElementById('edit-job-status').value = data.status||'in_progress';
       document.getElementById('edit-job-progress').value = Number(data.progress||0);
       document.getElementById('edit-job-start').value = data.start_at ? new Date(data.start_at).toISOString().slice(0,16) : '';
       document.getElementById('edit-job-due').value = data.due_at ? new Date(data.due_at).toISOString().slice(0,16) : '';
-      document.getElementById('edit-job-desc').value = data.description||'';
+      document.getElementById('edit-job-desc').value = stripCategoryOverride(data.description || '');
       openDialog(modalEditJob);
     };
   }
   if(btnSaveEditJob){
     btnSaveEditJob.onclick = async ()=>{
       const id = document.getElementById('edit-job-id').value;
+      const selectedCat = document.getElementById('edit-job-category').value;
+      const descValue = document.getElementById('edit-job-desc').value;
       const payload = {
         title: document.getElementById('edit-job-title').value.trim(),
-        category: document.getElementById('edit-job-category').value,
+        category: normalizeCategoryValue(selectedCat),
         status: document.getElementById('edit-job-status').value,
         progress: Number(document.getElementById('edit-job-progress').value||0),
         start_at: document.getElementById('edit-job-start').value || null,
         due_at: document.getElementById('edit-job-due').value || null,
-        description: document.getElementById('edit-job-desc').value.trim()
+        description: encodeCategoryOverride(descValue.trim(), selectedCat)
       };
       if(!payload.title){ toast('Título requerido','error'); return; }
       const { error } = await sb.from('jobs').update(payload).eq('id', id);
@@ -763,11 +832,13 @@ async function loadClientsIntoSelect(){
 
 // ---------- Jobs ----------
 document.getElementById("btn-save-job").onclick = async ()=>{
+  const selectedCat = document.getElementById("job-category").value;
+  const descriptionInput = document.getElementById("job-desc").value;
   const obj = {
     client_id: document.getElementById("job-client").value || null,
     title: document.getElementById("job-title").value.trim(),
-    category: document.getElementById("job-category").value,
-    description: document.getElementById("job-desc").value.trim(),
+    category: normalizeCategoryValue(selectedCat),
+    description: encodeCategoryOverride(descriptionInput.trim(), selectedCat),
     start_at: document.getElementById("job-start").value || null,
     due_at: document.getElementById("job-due").value || null
   };
@@ -949,9 +1020,14 @@ async function loadJobsTable(){
   const tbody = document.getElementById("jobs-tbody");
   if(!tbody) return;
   const q = (document.getElementById('jobs-search')?.value || '').toLowerCase();
-  const rows = (data||[]).filter(j=>{
+  const overrideMap = await resolveCategoryOverrides(data);
+  const enriched = (data||[]).map(j=>{
+    const override = overrideMap[j.id];
+    return { ...j, _categoryDisplay: override || j.category };
+  });
+  const rows = enriched.filter(j=>{
     if(!q) return true;
-    return [j.title, j.client_name, j.category, j.status].join(' ').toLowerCase().includes(q);
+    return [j.title, j.client_name, j._categoryDisplay, j.status].join(' ').toLowerCase().includes(q);
   }).map(j=>{
     const statusLabel = ({ done:"Completado", on_hold:"Pausado", in_progress:"En progreso" })[j.status] || j.status;
     const eta = j.due_at ? dayjs(j.due_at).format('DD/MM HH:mm') : '';
@@ -959,7 +1035,7 @@ async function loadJobsTable(){
       <tr>
         <td>${j.title}</td>
         <td>${j.client_name||""}</td>
-        <td>${catPill(j.category)}</td>
+        <td>${catPill(j._categoryDisplay)}</td>
         <td><span class="pill">${statusLabel}</span></td>
         <td class="progress-cell"><div class="progress"><span style="width:${j.progress||0}%"></span></div></td>
         <td>${eta}</td>

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -376,7 +376,16 @@ $search.oninput = ()=>{ filter.q = $search.value.trim(); loadJobs(); };
 
 // ---------- Jobs grid ----------
 let currentJob = null;
-function catPill(cat){ return {web:"Web", automations:"Automatizaciones", support:"Soporte", maintenance:"Mantenimiento"}[cat] || cat; }
+function catPill(cat){
+  return {
+    web: "Web",
+    automations: "Automatizaciones",
+    support: "Soporte",
+    maintenance: "Mantenimiento",
+    mobile_app: "Desarrollo App Móvil",
+    desktop_app: "Desarrollo App escritorio",
+  }[cat] || cat;
+}
 function statusColor(st){
   return st==="done" ? "border-color:#16a34a" : st==="on_hold" ? "border-color:#eab308" :
          st==="in_progress" ? "border-color:#38bdf8" : "border-color:#1f2937";

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -206,14 +206,11 @@ try{
 // ---------- App boot ----------
 async function boot(){
   const { data: { user } } = await sb.auth.getUser();
-  const back = document.getElementById('backHome');
   if(!user){
-    if(back) back.classList.remove('hidden');
     $auth.classList.remove('hidden');
     $app.classList.add('hidden');
     return;
   }
-  if(back) back.classList.add('hidden');
   const me = await getMe();
   try{ setupBrandUI(); await updateBrandValues(); }catch(e){}
   const displayName = (user.user_metadata && (user.user_metadata.full_name || user.user_metadata.name)) || me.full_name || user.email;
@@ -241,16 +238,9 @@ async function boot(){
   try{ initSidebarToggle(); }catch(e){}
 }
 
-// Intento de arranque inicial (evita que se vea el botón al tener sesión)
+// Intento de arranque inicial
 try{ boot(); }catch(e){}
 
-// Asegurar visibilidad correcta al cambiar estado de auth
-try{
-  sb.auth.onAuthStateChange((_event, session)=>{
-    const back = document.getElementById('backHome');
-    if(session){ back?.classList.add('hidden'); } else { back?.classList.remove('hidden'); }
-  });
-}catch(e){}
 
 async function ensureProfile(){
   const { data: { user } } = await sb.auth.getUser();

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -62,8 +62,14 @@
         <input type="password" id="signup-password" placeholder="Mín. 8 caracteres" required>
         <label>Rol</label>
         <select id="signup-role">
+          <option value="Tecnico" selected>Tecnico</option>
+          <option value="Asesor">Asesor</option>
+          <option value="Desarrollador Frontend">Desarrollador Frontend</option>
+          <option value="Desarrollador Backend">Desarrollador Backend</option>
+          <option value="Desarrollador Full Stack">Desarrollador Full Stack</option>
+          <option value="Diseñadores UX y UI">Diseñadores UX y UI</option>
           <option value="Administrador">Administrador</option>
-          <option value="Empleado">Empleado</option>
+          <option value="CEO">CEO</option>
         </select>
         <button type="submit" class="btn btn-primary w-full">Crear cuenta</button>
       </form>
@@ -462,8 +468,14 @@
         <input id="edit-user-name" placeholder="Nombre Apellido">
         <label>Rol</label>
         <select id="edit-user-role">
+          <option value="Tecnico">Tecnico</option>
+          <option value="Asesor">Asesor</option>
+          <option value="Desarrollador Frontend">Desarrollador Frontend</option>
+          <option value="Desarrollador Backend">Desarrollador Backend</option>
+          <option value="Desarrollador Full Stack">Desarrollador Full Stack</option>
+          <option value="Diseñadores UX y UI">Diseñadores UX y UI</option>
           <option value="Administrador">Administrador</option>
-          <option value="Empleado">Empleado</option>
+          <option value="CEO">CEO</option>
         </select>
         <label>Número de teléfono</label>
         <input id="edit-user-phone" type="tel" placeholder="+57 300 000 0000">
@@ -499,7 +511,7 @@
         <input id="profile-password" type="password" placeholder="Mín. 8 caracteres">
         <label>Confirmar contraseña</label>
         <input id="profile-password2" type="password" placeholder="Repite la contraseña">
-        <div class="hint">* El rol lo gestiona un Administrador. Si no quieres cambiar la contraseña, deja los campos en blanco.</div>
+        <div class="hint">* El rol lo gestiona un Administrador o CEO. Si no quieres cambiar la contraseña, deja los campos en blanco.</div>
         <button id="btn-save-profile" class="btn btn-primary">Guardar cambios</button>
       </div>
     </div>

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -562,12 +562,17 @@
   </dialog>
 
   <!-- Modal Boot/Verificando conexión -->
-  <dialog id="modal-boot" class="modal" tabindex="-1">
+  <dialog id="modal-boot" class="modal modal-boot" tabindex="-1">
     <div class="modal-content">
-      <div class="modal-head">
-        <h3>Verificando conexión</h3>
+      <div class="boot-pulse">
+        <span class="boot-ring"></span>
+        <span class="boot-ring"></span>
+        <div class="boot-core"><i data-lucide="wifi"></i></div>
       </div>
-      <p class="muted">Preparando tu experiencia segura…</p>
+      <div class="boot-copy">
+        <h3>Verificando conexión</h3>
+        <p>Sincronizando con la red segura de D TECH SOLUTIONS…</p>
+      </div>
     </div>
   </dialog>
 

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -120,7 +120,7 @@
             <h2>D TECH SOLUTIONS - ÁREA DE TRABAJO</h2>
           </div>
           <div class="right">
-            <button id="btn-toggle-theme" class="btn btn-ghost small" title="Cambiar tema">
+            <button id="btn-toggle-theme" class="btn btn-ghost" title="Cambiar tema">
               <i data-lucide="moon"></i><span>Tema</span>
             </button>
             <button id="btn-open-new" class="btn btn-primary">

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -126,6 +126,9 @@
             <button id="btn-open-new" class="btn btn-primary">
               <i data-lucide="plus"></i><span>Nuevo</span>
             </button>
+            <a id="backHome" class="btn btn-back-home" href="../Web%20Principal/index.html" title="Volver a Web Principal" aria-label="Volver a Web Principal">
+              <i data-lucide="home"></i><span>Inicio</span>
+            </a>
           </div>
         </header>
 
@@ -567,11 +570,6 @@
       <p class="muted">Preparando tu experiencia segura…</p>
     </div>
   </dialog>
-
-  <!-- Volver a Web Principal -->
-  <a id="backHome" class="back-home hidden" href="../Web%20Principal/index.html" title="Volver a Web Principal" aria-label="Volver a Web Principal">
-    <img src="./assets/logo.png" alt="D TECH SOLUTIONS" />
-  </a>
 
   <script src="./supabase.js"></script>
   <script src="./app.js"></script>

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -160,6 +160,8 @@
               <button class="chip" data-cat="automations">Automatizaciones</button>
               <button class="chip" data-cat="support">Soportes</button>
               <button class="chip" data-cat="maintenance">Mantenimientos</button>
+              <button class="chip" data-cat="mobile_app">Desarrollo App Móvil</button>
+              <button class="chip" data-cat="desktop_app">Desarrollo App escritorio</button>
             </div>
             <div class="search">
               <input id="search-input" type="text" placeholder="Buscar cliente o trabajo...">
@@ -361,6 +363,8 @@
           <option value="automations">Automatizaciones</option>
           <option value="support">Soportes</option>
           <option value="maintenance">Mantenimientos</option>
+          <option value="mobile_app">Desarrollo App Móvil</option>
+          <option value="desktop_app">Desarrollo App escritorio</option>
         </select>
         <label>Descripción</label>
         <textarea id="job-desc" rows="3"></textarea>
@@ -518,6 +522,8 @@
           <option value="automations">Automatizaciones</option>
           <option value="support">Soportes</option>
           <option value="maintenance">Mantenimientos</option>
+          <option value="mobile_app">Desarrollo App Móvil</option>
+          <option value="desktop_app">Desarrollo App escritorio</option>
         </select>
         <label>Estado</label>
         <select id="edit-job-status">

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -562,7 +562,7 @@
   </dialog>
 
   <!-- Modal Boot/Verificando conexión -->
-  <dialog id="modal-boot" class="modal modal-boot" tabindex="-1">
+  <dialog id="modal-boot" class="modal modal-boot">
     <div class="modal-content">
       <div class="boot-pulse">
         <span class="boot-ring"></span>

--- a/Panel Adminstrador/styles.css
+++ b/Panel Adminstrador/styles.css
@@ -149,6 +149,61 @@ textarea{resize:vertical}
 .modal-content{
   width:min(680px, 92vw); background:#ffffff; border:1px solid #e5e7eb; border-radius:20px; padding:16px; box-shadow:var(--shadow);
 }
+.modal-boot .modal-content{
+  display:flex;
+  align-items:center;
+  gap:22px;
+  padding:26px 30px;
+  border:none;
+  border-radius:28px;
+  background:
+    radial-gradient(160px 120px at 12% 20%, rgba(37,99,235,.18), transparent 70%),
+    radial-gradient(220px 180px at 85% 10%, rgba(34,211,238,.14), transparent 65%),
+    var(--panel);
+  box-shadow:0 24px 55px rgba(15,23,42,.35);
+  backdrop-filter:blur(14px);
+}
+.modal-boot .boot-pulse{
+  position:relative;
+  width:90px;
+  height:90px;
+  display:grid;
+  place-items:center;
+}
+.modal-boot .boot-ring{
+  position:absolute;
+  inset:0;
+  border-radius:999px;
+  border:2px solid rgba(37,99,235,.25);
+  animation:bootPulse 2.4s ease-in-out infinite;
+}
+.modal-boot .boot-ring:nth-child(2){ animation-delay:.8s }
+.modal-boot .boot-core{
+  width:54px;
+  height:54px;
+  border-radius:18px;
+  background:linear-gradient(135deg, var(--accent), var(--accent2));
+  display:grid;
+  place-items:center;
+  box-shadow:0 0 28px rgba(37,99,235,.55);
+}
+.modal-boot .boot-core i{ width:26px; height:26px; color:#ffffff }
+.modal-boot .boot-copy h3{
+  margin:0 0 6px;
+  font:700 1.25rem "Space Grotesk";
+  color:var(--text);
+  text-shadow:0 0 14px rgba(56,189,248,.42);
+}
+.modal-boot .boot-copy p{
+  margin:0;
+  color:var(--muted);
+  font-size:.95rem;
+}
+@keyframes bootPulse{
+  0%{ transform:scale(.7); opacity:.65 }
+  60%{ transform:scale(1.25); opacity:0 }
+  100%{ opacity:0 }
+}
 .modal-head{display:flex; align-items:center; justify-content:space-between; margin-bottom:8px}
 .row-2{display:grid; grid-template-columns:1fr 1fr; gap:10px}
 
@@ -208,7 +263,6 @@ textarea{resize:vertical}
   .kanban{display:grid; grid-auto-flow:column; grid-auto-columns:minmax(240px, 1fr); overflow-x:auto; gap:10px}
 }
 
-#modal-boot .modal-content{ border:2px solid #000; border-radius:0 }
 
 /* Widgets layout tweaks */
 #w-activity{ max-height:260px; overflow:auto }
@@ -224,8 +278,8 @@ textarea{resize:vertical}
   /* Paleta negra con alto contraste */
   --bg:#0a0a0b; --panel:#0e0f12; --panel2:#0b0c0f;
   --muted:#cbd5e1; --text:#ffffff;
-  /* Sin azul: acentos verdes vibrantes */
-  --accent:#22c55e; --accent2:#16a34a;
+  /* Acentos azules consistentes con el modo claro */
+  --accent:#2563eb; --accent2:#22d3ee;
   --shadow: 0 8px 24px rgba(0,0,0,.6);
 }
 [data-theme="dark"] body{ color:var(--text); background: var(--bg); }
@@ -262,7 +316,7 @@ textarea{resize:vertical}
 
 /* Botones en oscuro */
 [data-theme="dark"] .btn-ghost{ background:#0f1115; border-color:#2a2d33; color:var(--text) }
-[data-theme="dark"] .btn-primary{ background:linear-gradient(90deg, var(--accent), var(--accent2)); color:#fff; box-shadow:0 6px 22px rgba(34,197,94,.25) }
+[data-theme="dark"] .btn-primary{ background:linear-gradient(90deg, var(--accent), var(--accent2)); color:#fff; box-shadow:0 6px 22px rgba(37,99,235,.28) }
 [data-theme="dark"] .btn-back-home{ background:#000000; border-color:#000000; color:#ffffff; box-shadow:0 12px 28px rgba(0,0,0,.58) }
 [data-theme="dark"] .btn-back-home:hover{ background:#020617; border-color:#020617; box-shadow:0 16px 32px rgba(0,0,0,.68) }
 
@@ -279,10 +333,31 @@ textarea{resize:vertical}
 [data-theme="dark"] .column{ background:#0f1115; border-color:#24262b }
 [data-theme="dark"] .task{ background:#0f1115; border-color:#262a30 }
 
+/* Textos originalmente gris pizarra */
+[data-theme="dark"] .tab,
+[data-theme="dark"] label{ color:#f8fbff; text-shadow:0 0 8px rgba(56,189,248,.45) }
+[data-theme="dark"] .tab{ background:#111827; border-color:#1f2937 }
+[data-theme="dark"] .tab.active{
+  background:linear-gradient(135deg, rgba(37,99,235,.24), rgba(34,211,238,.16));
+  border-color:var(--accent);
+  box-shadow:0 0 0 2px rgba(37,99,235,.28);
+  color:#ffffff;
+}
+[data-theme="dark"] .modal-boot .modal-content{
+  background:
+    radial-gradient(220px 160px at 12% 25%, rgba(37,99,235,.28), transparent 75%),
+    radial-gradient(260px 200px at 88% 8%, rgba(34,211,238,.22), transparent 70%),
+    var(--panel);
+  box-shadow:0 30px 70px rgba(2,6,23,.55);
+}
+[data-theme="dark"] .modal-boot .boot-ring{ border-color:rgba(56,189,248,.45) }
+[data-theme="dark"] .modal-boot .boot-core{ box-shadow:0 0 36px rgba(56,189,248,.62) }
+[data-theme="dark"] .modal-boot .boot-copy p{ color:#94a3b8 }
+
 /* Badges y chips */
 [data-theme="dark"] .badge{ background:#0f1115; border:1px solid #2a2d33; color:var(--text) }
-[data-theme="dark"] .badge.role{ border-color:var(--accent); background:rgba(34,197,94,.12); color:#bbf7d0 }
-[data-theme="dark"] .badge.role.admin{ border-color:#22c55e; background:rgba(34,197,94,.18); color:#ecfdf5 }
+[data-theme="dark"] .badge.role{ border-color:var(--accent); background:rgba(37,99,235,.14); color:#bfdbfe }
+[data-theme="dark"] .badge.role.admin{ border-color:#38bdf8; background:rgba(56,189,248,.18); color:#e0f2fe }
 
 /* Filtros y chips */
 [data-theme="dark"] .filters{ color:var(--text) }
@@ -297,16 +372,16 @@ textarea{resize:vertical}
 }
 [data-theme="dark"] .chip.active{
   border-color:var(--accent);
-  background:rgba(34,197,94,.16);
-  box-shadow:0 0 0 2px rgba(34,197,94,.18);
-  color:#ecfdf5;
+  background:rgba(37,99,235,.16);
+  box-shadow:0 0 0 2px rgba(37,99,235,.2);
+  color:#e2e8f0;
 }
 
 /* Sidebar y navegación */
 [data-theme="dark"] .sidebar{ background:#0e0f12; border-right:1px solid #1f2227 }
 [data-theme="dark"] .nav-item{ background:#0f1115; border-color:#262a30; color:var(--text) }
 [data-theme="dark"] .nav-item:hover{ border-color:#2f343b }
-[data-theme="dark"] .nav-item.active{ box-shadow:0 0 0 2px rgba(34,197,94,.16) }
+[data-theme="dark"] .nav-item.active{ box-shadow:0 0 0 2px rgba(37,99,235,.2) }
 [data-theme="dark"] .topbar .btn-ghost{ background:#0f1115; border-color:#2a2d33 }
 
 /* Jobs grid */
@@ -329,6 +404,6 @@ textarea{resize:vertical}
 [data-theme="dark"] .job small{ color:var(--text); }
 [data-theme="dark"] .job .pill.st-done{ background:rgba(34,197,94,.18); border-color:#22c55e; color:#dcfce7 }
 [data-theme="dark"] .job .pill.st-on_hold{ background:rgba(234,179,8,.16); border-color:#facc15; color:#fef9c3 }
-[data-theme="dark"] .job .pill.st-in_progress{ background:rgba(59,130,246,.18); border-color:#60a5fa; color:#dbeafe }
+[data-theme="dark"] .job .pill.st-in_progress{ background:rgba(59,130,246,.24); border-color:#60a5fa; color:#dbeafe }
 [data-theme="dark"] .job .pill.st-new{ background:#1c2431; border-color:#2a2d33; color:#e2e8f0 }
-[data-theme="dark"] .job.selected{ outline-color:var(--accent); box-shadow:0 0 0 1px rgba(34,197,94,.22) }
+[data-theme="dark"] .job.selected{ outline-color:var(--accent); box-shadow:0 0 0 1px rgba(37,99,235,.24) }

--- a/Panel Adminstrador/styles.css
+++ b/Panel Adminstrador/styles.css
@@ -157,10 +157,9 @@ textarea{resize:vertical}
   border:none;
   border-radius:28px;
   background:
-    radial-gradient(160px 120px at 12% 20%, rgba(37,99,235,.18), transparent 70%),
-    radial-gradient(220px 180px at 85% 10%, rgba(34,211,238,.14), transparent 65%),
-    var(--panel);
-  box-shadow:0 24px 55px rgba(15,23,42,.35);
+    radial-gradient(220px 160px at 12% 25%, rgba(37,99,235,.28), transparent 75%),
+    radial-gradient(260px 200px at 88% 8%, rgba(34,211,238,.22), transparent 70%),
+    #0e0f1200;
   backdrop-filter:blur(14px);
 }
 .modal-boot .boot-pulse{

--- a/Panel Adminstrador/styles.css
+++ b/Panel Adminstrador/styles.css
@@ -282,8 +282,45 @@ textarea{resize:vertical}
 [data-theme="dark"] .badge.role{ border-color:var(--accent); background:rgba(34,197,94,.12); color:#bbf7d0 }
 [data-theme="dark"] .badge.role.admin{ border-color:#22c55e; background:rgba(34,197,94,.18); color:#ecfdf5 }
 
+/* Filtros y chips */
+[data-theme="dark"] .filters{ color:var(--text) }
+[data-theme="dark"] .chip{
+  background:#0f1115;
+  border-color:#2a2d33;
+  color:var(--text);
+  box-shadow:none;
+}
+[data-theme="dark"] .chip:hover{
+  border-color:#343943;
+}
+[data-theme="dark"] .chip.active{
+  border-color:var(--accent);
+  background:rgba(34,197,94,.16);
+  box-shadow:0 0 0 2px rgba(34,197,94,.18);
+  color:#ecfdf5;
+}
+
 /* Sidebar y navegación */
 [data-theme="dark"] .sidebar{ background:#0e0f12; border-right:1px solid #1f2227 }
 [data-theme="dark"] .nav-item{ background:#0f1115; border-color:#262a30; color:var(--text) }
 [data-theme="dark"] .nav-item:hover{ border-color:#2f343b }
 [data-theme="dark"] .nav-item.active{ box-shadow:0 0 0 2px rgba(34,197,94,.16) }
+[data-theme="dark"] .topbar .btn-ghost{ background:#0f1115; border-color:#2a2d33 }
+
+/* Jobs grid */
+[data-theme="dark"] .grid{ color:var(--text) }
+[data-theme="dark"] .job{
+  background:#0f1115;
+  border-color:#262a30;
+  box-shadow:0 8px 22px rgba(0,0,0,.35);
+}
+[data-theme="dark"] .job:hover{ box-shadow:0 10px 28px rgba(0,0,0,.45) }
+[data-theme="dark"] .job .pill{
+  background:#111822;
+  border-color:#2a2d33;
+  color:var(--text);
+}
+[data-theme="dark"] .job .pill.st-done{ background:rgba(34,197,94,.18); border-color:#22c55e; color:#dcfce7 }
+[data-theme="dark"] .job .pill.st-on_hold{ background:rgba(234,179,8,.16); border-color:#facc15; color:#fef9c3 }
+[data-theme="dark"] .job .pill.st-in_progress{ background:rgba(59,130,246,.18); border-color:#60a5fa; color:#dbeafe }
+[data-theme="dark"] .job .pill.st-new{ background:#1c2431; border-color:#2a2d33; color:#e2e8f0 }

--- a/Panel Adminstrador/styles.css
+++ b/Panel Adminstrador/styles.css
@@ -47,11 +47,13 @@ textarea{resize:vertical}
 .hint{color:#64748b; font-size:.85rem}
 
 /* Buttons (normalizados) */
-.btn{display:inline-flex; align-items:center; gap:8px; height:40px; padding:0 14px; border-radius:12px; cursor:pointer; border:1px solid transparent; font-weight:600}
+.btn{display:inline-flex; align-items:center; gap:8px; height:40px; padding:0 14px; border-radius:12px; cursor:pointer; border:1px solid transparent; font-weight:600; text-decoration:none}
 .btn span{line-height:1}
 .btn-primary{background:linear-gradient(90deg, var(--accent), var(--accent2)); color:#ffffff; border-color:transparent; box-shadow:0 4px 18px rgba(37,99,235,.18)}
 .btn-ghost{background:#ffffff; border-color:#e5e7eb; color:#0f172a}
 .btn-icon{background:transparent; border:none; color:inherit; cursor:pointer; height:40px; width:40px; display:grid; place-items:center}
+.btn-back-home{background:#0f172a; border-color:#0f172a; color:#ffffff; box-shadow:0 6px 18px rgba(15,23,42,.28)}
+.btn-back-home:hover{background:#020617; border-color:#020617; box-shadow:0 10px 26px rgba(2,6,23,.36)}
 .small{height:34px; padding:0 12px}
 .w-full{width:100%}
 
@@ -188,10 +190,8 @@ textarea{resize:vertical}
 .auth-card{ text-align:center }
 .auth-card .form{ text-align:left }
 
-/* Botón floting volver a Web Principal */
-.back-home{position:fixed;left:14px;bottom:14px;z-index:60;display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:12px;background:#ffffff;border:1px solid #e5e7eb;box-shadow:var(--shadow);cursor:pointer;transition:transform .15s ease, box-shadow .15s ease}
-.back-home:hover{transform:translateY(-1px);box-shadow:0 10px 24px rgba(15,23,42,.12)}
-.back-home img{width:26px;height:26px;border-radius:6px}
+/* Botón volver a web principal integrado en topbar */
+.btn-back-home i{width:18px; height:18px}
 
 /* Responsive */
 @media (max-width: 960px){
@@ -263,6 +263,8 @@ textarea{resize:vertical}
 /* Botones en oscuro */
 [data-theme="dark"] .btn-ghost{ background:#0f1115; border-color:#2a2d33; color:var(--text) }
 [data-theme="dark"] .btn-primary{ background:linear-gradient(90deg, var(--accent), var(--accent2)); color:#fff; box-shadow:0 6px 22px rgba(34,197,94,.25) }
+[data-theme="dark"] .btn-back-home{ background:#000000; border-color:#000000; color:#ffffff; box-shadow:0 12px 28px rgba(0,0,0,.58) }
+[data-theme="dark"] .btn-back-home:hover{ background:#020617; border-color:#020617; box-shadow:0 16px 32px rgba(0,0,0,.68) }
 
 /* Progresos y acentos */
 [data-theme="dark"] .progress{ background:#121317; border-color:#282a2f }
@@ -313,6 +315,7 @@ textarea{resize:vertical}
   background:#0f1115;
   border-color:#262a30;
   box-shadow:0 8px 22px rgba(0,0,0,.35);
+  color:var(--text);
 }
 [data-theme="dark"] .job:hover{ box-shadow:0 10px 28px rgba(0,0,0,.45) }
 [data-theme="dark"] .job .pill{
@@ -320,7 +323,12 @@ textarea{resize:vertical}
   border-color:#2a2d33;
   color:var(--text);
 }
+[data-theme="dark"] .job .row,
+[data-theme="dark"] .job .subrow,
+[data-theme="dark"] .job .title,
+[data-theme="dark"] .job small{ color:var(--text); }
 [data-theme="dark"] .job .pill.st-done{ background:rgba(34,197,94,.18); border-color:#22c55e; color:#dcfce7 }
 [data-theme="dark"] .job .pill.st-on_hold{ background:rgba(234,179,8,.16); border-color:#facc15; color:#fef9c3 }
 [data-theme="dark"] .job .pill.st-in_progress{ background:rgba(59,130,246,.18); border-color:#60a5fa; color:#dbeafe }
 [data-theme="dark"] .job .pill.st-new{ background:#1c2431; border-color:#2a2d33; color:#e2e8f0 }
+[data-theme="dark"] .job.selected{ outline-color:var(--accent); box-shadow:0 0 0 1px rgba(34,197,94,.22) }

--- a/Panel Adminstrador/styles.css
+++ b/Panel Adminstrador/styles.css
@@ -317,8 +317,17 @@ textarea{resize:vertical}
 /* Botones en oscuro */
 [data-theme="dark"] .btn-ghost{ background:#0f1115; border-color:#2a2d33; color:var(--text) }
 [data-theme="dark"] .btn-primary{ background:linear-gradient(90deg, var(--accent), var(--accent2)); color:#fff; box-shadow:0 6px 22px rgba(37,99,235,.28) }
-[data-theme="dark"] .btn-back-home{ background:#000000; border-color:#000000; color:#ffffff; box-shadow:0 12px 28px rgba(0,0,0,.58) }
-[data-theme="dark"] .btn-back-home:hover{ background:#020617; border-color:#020617; box-shadow:0 16px 32px rgba(0,0,0,.68) }
+[data-theme="dark"] .btn-back-home{
+  background:#ffffff;
+  border-color:#ffffff;
+  color:#0b1220;
+  box-shadow:0 14px 32px rgba(15,23,42,.4);
+}
+[data-theme="dark"] .btn-back-home:hover{
+  background:#f8fafc;
+  border-color:#f8fafc;
+  box-shadow:0 18px 36px rgba(15,23,42,.46);
+}
 
 /* Progresos y acentos */
 [data-theme="dark"] .progress{ background:#121317; border-color:#282a2f }
@@ -342,6 +351,18 @@ textarea{resize:vertical}
   border-color:var(--accent);
   box-shadow:0 0 0 2px rgba(37,99,235,.28);
   color:#ffffff;
+}
+[data-theme="dark"] .hint,
+[data-theme="dark"] .brand-text small,
+[data-theme="dark"] .user-brand .brand-text small,
+[data-theme="dark"] .list .meta,
+[data-theme="dark"] .stat .stat-top,
+[data-theme="dark"] .col-title,
+[data-theme="dark"] .task .t2,
+[data-theme="dark"] .update-meta,
+[data-theme="dark"] .update-note{
+  color:var(--text);
+  text-shadow:0 0 6px rgba(148,163,184,.35);
 }
 [data-theme="dark"] .modal-boot .modal-content{
   background:

--- a/Panel Adminstrador/styles.css
+++ b/Panel Adminstrador/styles.css
@@ -23,6 +23,19 @@ body{
 .ring{width:32px; height:32px; border-radius:999px; border:3px solid rgba(0,0,0,.12); border-top-color:#2563eb; animation:spin 0.9s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
 .spinner .txt strong{display:block}
+[data-theme="dark"] .overlay{background:rgba(2,6,23,.68); backdrop-filter:blur(3px)}
+[data-theme="dark"] .spinner{
+  background:#0e1014;
+  border:1px solid #1f2937;
+  box-shadow:0 26px 54px rgba(2,6,23,.58);
+  color:#f8fbff;
+}
+[data-theme="dark"] .spinner .txt strong,
+[data-theme="dark"] .spinner .txt small{color:#f8fbff; text-shadow:0 0 10px rgba(37,99,235,.32)}
+[data-theme="dark"] .ring{
+  border-color:rgba(148,163,184,.18);
+  border-top-color:var(--accent);
+}
 
 /* Auth */
 .auth{display:grid; place-items:center; height:100vh; padding:24px}
@@ -159,8 +172,9 @@ textarea{resize:vertical}
   background:
     radial-gradient(220px 160px at 12% 25%, rgba(37,99,235,.28), transparent 75%),
     radial-gradient(260px 200px at 88% 8%, rgba(34,211,238,.22), transparent 70%),
-    #0e0f1200;
+    var(--panel);
   backdrop-filter:blur(14px);
+  box-shadow:0 22px 50px rgba(15,23,42,.16);
 }
 .modal-boot .boot-pulse{
   position:relative;


### PR DESCRIPTION
## Summary
- adjust dark theme colors for filter chips and toggle buttons
- darken job grid cards and status pills to match overall theme

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9d46e852c83308195d732341b918c