### PR TITLE
Ensure dashboard job cards show budget figures

### DIFF
--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -1054,14 +1054,35 @@ async function loadJobs(){
     return j.category === requested;
   });
 
+  const jobIds = rows.map(j=> j.id).filter(Boolean);
+  let jobDetailsMap = {};
+  if(jobIds.length){
+    try{
+      const { data: jobDetails } = await sb
+        .from('jobs')
+        .select('id,presupuesto,costo_real,horas_estimadas,horas_reales')
+        .in('id', jobIds);
+      (jobDetails || []).forEach(job=>{
+        if(job && job.id) jobDetailsMap[job.id] = job;
+      });
+    }catch(err){
+      console.error('No se pudieron cargar los detalles de presupuesto de los proyectos', err);
+    }
+  }
+
   $grid.innerHTML = rows.map(j=>{
-    const budget = formatCurrencyCOP(j.presupuesto);
-    const actual = formatCurrencyCOP(j.costo_real);
-    const hoursEst = formatHoursValue(j.horas_estimadas);
-    const hoursReal = formatHoursValue(j.horas_reales);
+    const detail = jobDetailsMap[j.id] || {};
+    const presupuesto = detail.presupuesto ?? j.presupuesto;
+    const costoReal = detail.costo_real ?? j.costo_real;
+    const horasEst = detail.horas_estimadas ?? j.horas_estimadas;
+    const horasReal = detail.horas_reales ?? j.horas_reales;
+    const budget = formatCurrencyCOP(presupuesto);
+    const actual = formatCurrencyCOP(costoReal);
+    const hoursEstDisplay = formatHoursValue(horasEst);
+    const hoursRealDisplay = formatHoursValue(horasReal);
     const eta = j.due_at ? `Entrega ${formatDateTimeBogota(j.due_at)}` : '';
-    const deltaBudget = buildDeltaChip(j.costo_real, j.presupuesto);
-    const deltaHours = buildHoursDelta(j.horas_reales, j.horas_estimadas);
+    const deltaBudget = buildDeltaChip(costoReal, presupuesto);
+    const deltaHours = buildHoursDelta(horasReal, horasEst);
     return `
       <article class="job" data-id="${j.id}" style="${statusColor(j.status)}">
         <div class="row">
@@ -1077,7 +1098,7 @@ async function loadJobs(){
         <div class="job-finance">
           <div class="meta-row"><span>Presupuesto</span><strong>${budget}</strong></div>
           <div class="meta-row"><span>Costo real</span><span>${actual}</span>${deltaBudget}</div>
-          <div class="meta-row"><span>Horas</span><span class="hours-chip">Real ${hoursReal} · Est. ${hoursEst}</span>${deltaHours}</div>
+          <div class="meta-row"><span>Horas</span><span class="hours-chip">Real ${hoursRealDisplay} · Est. ${hoursEstDisplay}</span>${deltaHours}</div>
         </div>
       </article>
     `;

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -62,6 +62,11 @@ function buildInFilterString(values = []){
   return `(${unique.map(v=>`"${v}"`).join(',')})`;
 }
 
+function resolveJobCompletionDate(job){
+  if(!job) return null;
+  return job.completed_at || job.updated_at || job.due_at || job.created_at || null;
+}
+
 const JOB_STATUS_EXCLUDE_ACTIVE = buildInFilterString([ARCHIVED_STATUS, ...COMPLETED_STATUS_DB_VALUES]);
 
 let canManageUsers = false;
@@ -1916,16 +1921,23 @@ async function loadCompletedJobsTable(){
   const { data, error } = await sb
     .from('jobs_view')
     .select('*')
-    .in('status', Array.from(COMPLETED_STATUS_DB_SET))
-    .order('completed_at', { ascending:false, nullsFirst:false });
+    .in('status', Array.from(COMPLETED_STATUS_DB_SET));
   if(error){
     tbody.innerHTML = '';
     if(hint) hint.textContent = error.message || 'No fue posible cargar los trabajos completados.';
     toast(error.message || 'No fue posible cargar los trabajos completados.', 'error');
     return;
   }
+  const rowsData = (data || []).slice().sort((a,b)=>{
+    const aKey = resolveJobCompletionDate(a);
+    const bKey = resolveJobCompletionDate(b);
+    if(!aKey && !bKey) return 0;
+    if(!aKey) return 1;
+    if(!bKey) return -1;
+    return new Date(bKey).getTime() - new Date(aKey).getTime();
+  });
   const q = (document.getElementById('jobs-search')?.value || '').toLowerCase();
-  const filtered = (data || []).filter(j=>{
+  const filtered = rowsData.filter(j=>{
     if(!q) return true;
     return [j.title, j.client_name, j.category, j.status].join(' ').toLowerCase().includes(q);
   });
@@ -1948,7 +1960,7 @@ async function loadCompletedJobsTable(){
     const costoReal = detail.costo_real ?? j.costo_real;
     const horasEst = detail.horas_estimadas ?? j.horas_estimadas;
     const horasReal = detail.horas_reales ?? j.horas_reales;
-    const completedAt = j.completed_at || j.updated_at || j.due_at || j.created_at;
+    const completedAt = resolveJobCompletionDate(j);
     const when = completedAt ? formatDateTimeBogota(completedAt) : '';
     const budget = formatCurrencyCOP(presupuesto);
     const actual = formatCurrencyCOP(costoReal);

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -52,8 +52,17 @@ const ROLE_PRIORITY = { CEO:0, Administrador:1 };
 const BOGOTA_TZ = 'America/Bogota';
 const copFormatter = new Intl.NumberFormat('es-CO', { style:'currency', currency:'COP', maximumFractionDigits:0 });
 const ARCHIVED_STATUS = 'archived';
-const COMPLETED_STATUS_SET = new Set(['done','completed']);
-const JOB_STATUS_EXCLUDE_ACTIVE = `("${ARCHIVED_STATUS}","${Array.from(COMPLETED_STATUS_SET).join('","')}")`;
+const COMPLETED_STATUS_DB_VALUES = ['done'];
+const COMPLETED_STATUS_DB_SET = new Set(COMPLETED_STATUS_DB_VALUES);
+const COMPLETED_STATUS_DISPLAY_SET = new Set([...COMPLETED_STATUS_DB_VALUES, 'completed']);
+
+function buildInFilterString(values = []){
+  if(!values.length) return '()';
+  const unique = [...new Set(values.filter(Boolean))];
+  return `(${unique.map(v=>`"${v}"`).join(',')})`;
+}
+
+const JOB_STATUS_EXCLUDE_ACTIVE = buildInFilterString([ARCHIVED_STATUS, ...COMPLETED_STATUS_DB_VALUES]);
 
 let canManageUsers = false;
 let supportsBlocking = false;
@@ -1038,7 +1047,7 @@ function catPill(cat){
   return catLabel(cat);
 }
 function isCompletedStatus(st){
-  return COMPLETED_STATUS_SET.has(st);
+  return COMPLETED_STATUS_DISPLAY_SET.has(st);
 }
 function statusColor(st){
   if(isCompletedStatus(st)) return "border-color:#16a34a";
@@ -1907,8 +1916,8 @@ async function loadCompletedJobsTable(){
   const { data, error } = await sb
     .from('jobs_view')
     .select('*')
-    .in('status', Array.from(COMPLETED_STATUS_SET))
-    .order('updated_at', { ascending:false });
+    .in('status', Array.from(COMPLETED_STATUS_DB_SET))
+    .order('completed_at', { ascending:false, nullsFirst:false });
   if(error){
     tbody.innerHTML = '';
     if(hint) hint.textContent = error.message || 'No fue posible cargar los trabajos completados.';

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -51,6 +51,9 @@ const DEFAULT_ROLE = "Tecnico";
 const ROLE_PRIORITY = { CEO:0, Administrador:1 };
 const BOGOTA_TZ = 'America/Bogota';
 const copFormatter = new Intl.NumberFormat('es-CO', { style:'currency', currency:'COP', maximumFractionDigits:0 });
+const ARCHIVED_STATUS = 'archived';
+const COMPLETED_STATUS_SET = new Set(['done','completed']);
+const JOB_STATUS_EXCLUDE_ACTIVE = `("${ARCHIVED_STATUS}","${Array.from(COMPLETED_STATUS_SET).join('","')}")`;
 
 let canManageUsers = false;
 let supportsBlocking = false;
@@ -302,7 +305,7 @@ function showView(name){
   $navItems.forEach(n=> n.classList.toggle('active', n.dataset.view===name));
   lucide.createIcons();
   if(name==='clients') loadClientsList();
-  if(name==='jobs'){ loadJobsTable(); loadArchivedJobsTable(); }
+  if(name==='jobs'){ loadJobsTable(); loadCompletedJobsTable(); loadArchivedJobsTable(); }
   if(name==='users') loadUsersList();
 }
 $navItems.forEach(n=> n.onclick = ()=> showView(n.dataset.view));
@@ -560,7 +563,7 @@ async function getMe(){
 async function updateStats(){
   const [{ count: cClients }, { count: cJobs }] = await Promise.all([
     sb.from("clients").select("*", { count:"exact", head:true }),
-    sb.from("jobs").select("*", { count:"exact", head:true }).neq("status","archived"),
+    sb.from("jobs").select("*", { count:"exact", head:true }).not('status','in', JOB_STATUS_EXCLUDE_ACTIVE),
   ]);
   document.getElementById("stat-clients").textContent = cClients ?? 0;
   document.getElementById("stat-jobs").textContent    = cJobs ?? 0;
@@ -1033,17 +1036,22 @@ async function uploadTaskAttachments(taskId, files = []){
 function catPill(cat){
   return catLabel(cat);
 }
+function isCompletedStatus(st){
+  return COMPLETED_STATUS_SET.has(st);
+}
 function statusColor(st){
-  return st==="done" ? "border-color:#16a34a" : st==="on_hold" ? "border-color:#eab308" :
+  if(isCompletedStatus(st)) return "border-color:#16a34a";
+  return st==="on_hold" ? "border-color:#eab308" :
          st==="in_progress" ? "border-color:#38bdf8" : "border-color:#1f2937";
 }
 function statusLabel(st){
-  return st==="done" ? "Completado" : st==="on_hold" ? "Pausado" : st==="in_progress" ? "En progreso" : st==="new" ? "Nuevo" : st;
+  if(isCompletedStatus(st)) return "Completado";
+  return st==="on_hold" ? "Pausado" : st==="in_progress" ? "En progreso" : st==="new" ? "Nuevo" : st;
 }
 
 async function loadJobs(){
   const requested = filter.cat;
-  let q = sb.from("jobs_view").select("*").neq("status","archived");
+  let q = sb.from("jobs_view").select("*").not('status','in', JOB_STATUS_EXCLUDE_ACTIVE);
   if(requested!=="all") q = q.eq("category", requested);
   if(filter.q) q = q.ilike("search_text", `%${filter.q}%`);
   const { data, error } = await q.order("created_at",{ ascending:false });
@@ -1824,7 +1832,7 @@ async function loadJobsTable(){
   const { data, error } = await sb
     .from("jobs_view")
     .select("*")
-    .neq("status","archived")
+    .not('status','in', JOB_STATUS_EXCLUDE_ACTIVE)
     .order("created_at", { ascending:false });
   if(error){
     tbody.innerHTML = '';
@@ -1837,20 +1845,38 @@ async function loadJobsTable(){
     if(!q) return true;
     return [j.title, j.client_name, j.category, j.status].join(' ').toLowerCase().includes(q);
   });
+  const jobIds = filtered.map(j=> j.id).filter(Boolean);
+  const jobDetailsMap = {};
+  if(jobIds.length){
+    try{
+      const { data: details } = await sb
+        .from('jobs')
+        .select('id,presupuesto,costo_real,horas_estimadas,horas_reales')
+        .in('id', jobIds);
+      (details || []).forEach(job=>{ if(job && job.id) jobDetailsMap[job.id] = job; });
+    }catch(fetchError){
+      console.error('No se pudieron cargar los detalles financieros de los trabajos activos', fetchError);
+    }
+  }
   const rows = filtered.map(j=>{
-    const statusLabel = ({ done:"Completado", on_hold:"Pausado", in_progress:"En progreso" })[j.status] || j.status;
+    const detail = jobDetailsMap[j.id] || {};
+    const presupuesto = detail.presupuesto ?? j.presupuesto;
+    const costoReal = detail.costo_real ?? j.costo_real;
+    const horasEst = detail.horas_estimadas ?? j.horas_estimadas;
+    const horasReal = detail.horas_reales ?? j.horas_reales;
+    const displayStatus = statusLabel(j.status);
     const eta = j.due_at ? formatDateTimeBogota(j.due_at) : '';
-    const budget = formatCurrencyCOP(j.presupuesto);
-    const actual = formatCurrencyCOP(j.costo_real);
-    const hoursLabel = `Est. ${formatHoursValue(j.horas_estimadas)} · Real ${formatHoursValue(j.horas_reales)}`;
-    const deltaBudget = buildDeltaChip(j.costo_real, j.presupuesto);
-    const deltaHours = buildHoursDelta(j.horas_reales, j.horas_estimadas);
+    const budget = formatCurrencyCOP(presupuesto);
+    const actual = formatCurrencyCOP(costoReal);
+    const hoursLabel = `Est. ${formatHoursValue(horasEst)} · Real ${formatHoursValue(horasReal)}`;
+    const deltaBudget = buildDeltaChip(costoReal, presupuesto);
+    const deltaHours = buildHoursDelta(horasReal, horasEst);
     return `
       <tr>
         <td>${j.title}</td>
         <td>${j.client_name||""}</td>
         <td>${catPill(j.category)}</td>
-        <td><span class="pill">${statusLabel}</span></td>
+        <td><span class="pill">${displayStatus}</span></td>
         <td class="progress-cell"><div class="progress"><span style="width:${j.progress||0}%"></span></div></td>
         <td>${budget}</td>
         <td>${actual}<br>${deltaBudget}</td>
@@ -1866,7 +1892,81 @@ async function loadJobsTable(){
   }).join("");
   tbody.innerHTML = rows;
   if(hint){
-    hint.textContent = filtered.length ? 'Trabajos activos ordenados por fecha.' : 'Sin trabajos activos para mostrar.';
+    hint.textContent = filtered.length ? 'Trabajos activos sin finalizar ni archivar.' : 'Sin trabajos activos para mostrar.';
+  }
+  lucide.createIcons();
+  attachJobsTableHandlers();
+}
+
+async function loadCompletedJobsTable(){
+  const tbody = document.getElementById('jobs-completed-tbody');
+  const hint = document.getElementById('jobs-completed-hint');
+  if(!tbody) return;
+  if(hint) hint.textContent = 'Cargando completados…';
+  const { data, error } = await sb
+    .from('jobs_view')
+    .select('*')
+    .in('status', Array.from(COMPLETED_STATUS_SET))
+    .order('updated_at', { ascending:false });
+  if(error){
+    tbody.innerHTML = '';
+    if(hint) hint.textContent = error.message || 'No fue posible cargar los trabajos completados.';
+    toast(error.message || 'No fue posible cargar los trabajos completados.', 'error');
+    return;
+  }
+  const q = (document.getElementById('jobs-search')?.value || '').toLowerCase();
+  const filtered = (data || []).filter(j=>{
+    if(!q) return true;
+    return [j.title, j.client_name, j.category, j.status].join(' ').toLowerCase().includes(q);
+  });
+  const jobIds = filtered.map(j=> j.id).filter(Boolean);
+  const jobDetailsMap = {};
+  if(jobIds.length){
+    try{
+      const { data: details } = await sb
+        .from('jobs')
+        .select('id,presupuesto,costo_real,horas_estimadas,horas_reales')
+        .in('id', jobIds);
+      (details || []).forEach(job=>{ if(job && job.id) jobDetailsMap[job.id] = job; });
+    }catch(fetchError){
+      console.error('No se pudieron cargar los detalles financieros de los trabajos completados', fetchError);
+    }
+  }
+  const rows = filtered.map(j=>{
+    const detail = jobDetailsMap[j.id] || {};
+    const presupuesto = detail.presupuesto ?? j.presupuesto;
+    const costoReal = detail.costo_real ?? j.costo_real;
+    const horasEst = detail.horas_estimadas ?? j.horas_estimadas;
+    const horasReal = detail.horas_reales ?? j.horas_reales;
+    const completedAt = j.completed_at || j.updated_at || j.due_at || j.created_at;
+    const when = completedAt ? formatDateTimeBogota(completedAt) : '';
+    const budget = formatCurrencyCOP(presupuesto);
+    const actual = formatCurrencyCOP(costoReal);
+    const hoursLabel = `Est. ${formatHoursValue(horasEst)} · Real ${formatHoursValue(horasReal)}`;
+    const deltaBudget = buildDeltaChip(costoReal, presupuesto);
+    const deltaHours = buildHoursDelta(horasReal, horasEst);
+    const displayStatus = statusLabel(j.status);
+    return `
+      <tr>
+        <td>${j.title}</td>
+        <td>${j.client_name||''}</td>
+        <td>${catPill(j.category)}</td>
+        <td><span class="pill">${displayStatus}</span></td>
+        <td>${budget}</td>
+        <td>${actual}<br>${deltaBudget}</td>
+        <td><span class="hours-chip">${hoursLabel}</span><br>${deltaHours}</td>
+        <td>${when}</td>
+        <td>
+          <button class="btn btn-ghost small" title="Abrir" data-open-job="${j.id}"><i data-lucide="external-link"></i></button>
+          <button class="btn btn-ghost small" title="Editar" data-edit-job-row="${j.id}"><i data-lucide="pencil"></i></button>
+          <button class="btn btn-ghost small" title="Archivar" data-archive-job="${j.id}"><i data-lucide="archive"></i></button>
+        </td>
+      </tr>
+    `;
+  }).join('');
+  tbody.innerHTML = rows;
+  if(hint){
+    hint.textContent = filtered.length ? 'Trabajos finalizados listos para consulta.' : 'Sin trabajos completados.';
   }
   lucide.createIcons();
   attachJobsTableHandlers();
@@ -1880,7 +1980,7 @@ async function loadArchivedJobsTable(){
   const { data, error } = await sb
     .from('jobs_view')
     .select('*')
-    .eq('status', 'archived')
+    .eq('status', ARCHIVED_STATUS)
     .order('created_at', { ascending:false });
   if(error){
     tbody.innerHTML = '';
@@ -1901,21 +2001,43 @@ async function loadArchivedJobsTable(){
     if(!q) return true;
     return [j.title, j.client_name, j.category].join(' ').toLowerCase().includes(q);
   });
+  const jobIds = filtered.map(j=> j.id).filter(Boolean);
+  const jobDetailsMap = {};
+  if(jobIds.length){
+    try{
+      const { data: details } = await sb
+        .from('jobs')
+        .select('id,presupuesto,costo_real,horas_reales')
+        .in('id', jobIds);
+      (details || []).forEach(job=>{ if(job && job.id) jobDetailsMap[job.id] = job; });
+    }catch(fetchError){
+      console.error('No se pudieron cargar los detalles financieros de los trabajos archivados', fetchError);
+    }
+  }
   const rows = filtered.map(j=>{
     const archivedAt = j.archived_at || j.updated_at || j.created_at;
     const when = archivedAt ? formatDateTimeBogota(archivedAt) : '';
-    const budget = formatCurrencyCOP(j.presupuesto);
-    const actual = formatCurrencyCOP(j.costo_real);
-    const hoursReal = formatHoursValue(j.horas_reales);
+    const detail = jobDetailsMap[j.id] || {};
+    const presupuesto = detail.presupuesto ?? j.presupuesto;
+    const costoReal = detail.costo_real ?? j.costo_real;
+    const horasRealValue = detail.horas_reales ?? j.horas_reales;
+    const budget = formatCurrencyCOP(presupuesto);
+    const actual = formatCurrencyCOP(costoReal);
+    const deltaBudget = buildDeltaChip(costoReal, presupuesto);
+    const hoursReal = formatHoursValue(horasRealValue);
     return `
       <tr>
         <td>${j.title}</td>
         <td>${j.client_name||''}</td>
         <td>${catPill(j.category)}</td>
         <td>${budget}</td>
-        <td>${actual}</td>
+        <td>${actual}<br>${deltaBudget}</td>
         <td>${hoursReal}</td>
         <td>${when}</td>
+        <td>
+          <button class="btn btn-ghost small" title="Abrir" data-open-job="${j.id}"><i data-lucide="external-link"></i></button>
+          <button class="btn btn-ghost small" title="Desarchivar" data-unarchive-job="${j.id}"><i data-lucide="archive-restore"></i></button>
+        </td>
       </tr>
     `;
   }).join('');
@@ -1923,6 +2045,8 @@ async function loadArchivedJobsTable(){
   if(hint){
     hint.textContent = filtered.length ? 'Historial de trabajos archivados.' : 'Sin trabajos archivados.';
   }
+  lucide.createIcons();
+  attachJobsTableHandlers();
 }
 
 // ---------- Empleados (solo admin ve todos) ----------
@@ -2074,7 +2198,7 @@ try{ initTaskGlobalControls(); }catch(e){}
 const $clientsSearch = document.getElementById('clients-search');
 if($clientsSearch) $clientsSearch.oninput = ()=> loadClientsList();
 const $jobsSearch = document.getElementById('jobs-search');
-if($jobsSearch) $jobsSearch.oninput = ()=>{ loadJobsTable(); loadArchivedJobsTable(); };
+if($jobsSearch) $jobsSearch.oninput = ()=>{ loadJobsTable(); loadCompletedJobsTable(); loadArchivedJobsTable(); };
 
 // Handlers de acciones en tablas
 function attachClientsTableHandlers(){
@@ -2215,6 +2339,7 @@ function attachJobsTableHandlers(){
   });
   document.querySelectorAll('[data-edit-job-row]').forEach(b=> b.onclick = ()=> openEditJobModal(b.dataset.editJobRow));
   document.querySelectorAll('[data-archive-job]').forEach(b=> b.onclick = ()=> archiveJob(b.dataset.archiveJob));
+  document.querySelectorAll('[data-unarchive-job]').forEach(b=> b.onclick = ()=> unarchiveJob(b.dataset.unarchiveJob));
 }
 async function openEditJobModal(id){
   const { data, error } = await sb.from('jobs').select('*').eq('id', id).single();
@@ -2243,17 +2368,27 @@ async function openEditJobModal(id){
 }
 async function archiveJob(id){
   if(!confirm('¿Archivar trabajo?')) return;
-  const { error } = await sb.from('jobs').update({ status:'archived' }).eq('id', id);
+  const { error } = await sb.from('jobs').update({ status: ARCHIVED_STATUS }).eq('id', id);
   if(error){ toast(error.message,'error'); return; }
   toast('Trabajo archivado','ok');
-  await loadJobsTable(); await loadArchivedJobsTable(); await loadJobs(); await updateStats();
+  await loadJobsTable(); await loadCompletedJobsTable(); await loadArchivedJobsTable(); await loadJobs(); await updateStats();
+}
+
+async function unarchiveJob(id){
+  if(!confirm('¿Desarchivar trabajo?')) return;
+  const { error } = await sb.from('jobs').update({ status:'in_progress' }).eq('id', id);
+  if(error){ toast(error.message,'error'); return; }
+  toast('Trabajo desarchivado','ok');
+  await loadJobsTable(); await loadCompletedJobsTable(); await loadArchivedJobsTable(); await loadJobs(); await updateStats();
 }
 
 // Botones de refresco
 const $btnRefClients = document.getElementById('btn-refresh-clients');
 if($btnRefClients) $btnRefClients.onclick = ()=> loadClientsList();
 const $btnRefJobs = document.getElementById('btn-refresh-jobs');
-if($btnRefJobs) $btnRefJobs.onclick = ()=>{ loadJobsTable(); loadArchivedJobsTable(); };
+if($btnRefJobs) $btnRefJobs.onclick = ()=>{ loadJobsTable(); loadCompletedJobsTable(); loadArchivedJobsTable(); };
+const $btnRefCompletedJobs = document.getElementById('btn-refresh-completed-jobs');
+if($btnRefCompletedJobs) $btnRefCompletedJobs.onclick = ()=> loadCompletedJobsTable();
 const $btnRefArchivedJobs = document.getElementById('btn-refresh-archived-jobs');
 if($btnRefArchivedJobs) $btnRefArchivedJobs.onclick = ()=> loadArchivedJobsTable();
 const $btnRefKanban = document.getElementById('btn-refresh-kanban');

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -32,6 +32,8 @@ const $grid = document.getElementById("jobs-grid");
 const $chips = document.querySelectorAll("#chip-categories .chip");
 const $search = document.getElementById("search-input");
 const $navItems = document.querySelectorAll(".nav-item");
+const $btnArchiveJobAction = document.getElementById('btn-archive-job');
+const $btnUnarchiveJobAction = document.getElementById('btn-unarchive-job');
 
 const CATEGORY_LABELS = {
   web: "Páginas web",
@@ -71,9 +73,28 @@ const JOB_STATUS_EXCLUDE_ACTIVE = buildInFilterString([ARCHIVED_STATUS, ...COMPL
 
 let canManageUsers = false;
 let supportsBlocking = false;
+let currentJobStatus = null;
 
 function isManager(role){
   return MANAGER_ROLES.has(role);
+}
+
+function updateJobActionButtons(status){
+  const nextStatus = status ?? currentJobStatus ?? null;
+  currentJobStatus = nextStatus || null;
+  const hasSelection = !!currentJob;
+  if($btnArchiveJobAction){
+    const shouldShowArchive = hasSelection && nextStatus && nextStatus !== ARCHIVED_STATUS;
+    $btnArchiveJobAction.style.display = shouldShowArchive ? '' : 'none';
+  }
+  if($btnUnarchiveJobAction){
+    const shouldShowUnarchive = hasSelection && nextStatus === ARCHIVED_STATUS;
+    $btnUnarchiveJobAction.style.display = shouldShowUnarchive ? '' : 'none';
+  }
+  if(!hasSelection){
+    if($btnArchiveJobAction) $btnArchiveJobAction.style.display = 'none';
+    if($btnUnarchiveJobAction) $btnUnarchiveJobAction.style.display = 'none';
+  }
 }
 
 function formatBogotaParts(value){
@@ -1131,7 +1152,13 @@ async function loadJobs(){
     el.onclick = async ()=>{
       currentJob = el.dataset.id;
       const job = (data||[]).find(x=>x.id===currentJob);
-      if(job) document.getElementById("kanban-title").textContent = job.title;
+      if(job){
+        document.getElementById("kanban-title").textContent = job.title;
+        currentJobStatus = job.status || null;
+      }else{
+        currentJobStatus = null;
+      }
+      updateJobActionButtons(currentJobStatus);
       document.querySelectorAll('.job').forEach(n=> n.classList.remove('selected'));
       el.classList.add('selected');
       await loadKanban();
@@ -1141,6 +1168,14 @@ async function loadJobs(){
   if(currentJob){
     const sel = document.querySelector(`.job[data-id="${currentJob}"]`);
     if(sel) sel.classList.add('selected');
+    const job = (data||[]).find(x=>x.id===currentJob);
+    if(job){
+      currentJobStatus = job.status || null;
+    }
+    updateJobActionButtons(currentJobStatus);
+  }else{
+    currentJobStatus = null;
+    updateJobActionButtons(null);
   }
 }
 
@@ -1382,6 +1417,20 @@ function enhanceUI(){
   const modalEditJob = document.getElementById('modal-edit-job');
   const btnEditJob = document.getElementById('btn-edit-job');
   const btnSaveEditJob = document.getElementById('btn-save-edit-job');
+  const btnArchiveJob = $btnArchiveJobAction;
+  const btnUnarchiveJob = $btnUnarchiveJobAction;
+  if(btnArchiveJob){
+    btnArchiveJob.onclick = async ()=>{
+      if(!currentJob){ toast('Selecciona un trabajo','error'); return; }
+      await archiveJob(currentJob);
+    };
+  }
+  if(btnUnarchiveJob){
+    btnUnarchiveJob.onclick = async ()=>{
+      if(!currentJob){ toast('Selecciona un trabajo','error'); return; }
+      await unarchiveJob(currentJob);
+    };
+  }
   if(btnEditJob && modalEditJob){
     btnEditJob.onclick = async ()=>{
       if(!currentJob){ toast('Selecciona un trabajo','error'); return; }
@@ -1411,9 +1460,15 @@ function enhanceUI(){
       if(error){ toast(error.message,'error'); return; }
       toast('Trabajo actualizado','ok');
       closeDialog(document.getElementById('modal-edit-job'));
+      if(currentJob === id){
+        currentJobStatus = payload.status || currentJobStatus;
+        updateJobActionButtons(currentJobStatus);
+      }
       await loadJobs(); await loadKanban(); await updateStats(); await loadJobProgressChart();
     };
   }
+
+  updateJobActionButtons(currentJobStatus);
 }
 
 // Cargar trabajos en el select del modal de tarea
@@ -2354,9 +2409,13 @@ function attachJobsTableHandlers(){
     currentJob = b.dataset.openJob; showView('dashboard');
     const titleEl = document.getElementById('kanban-title');
     try{
-      const { data } = await sb.from('jobs').select('title').eq('id', currentJob).single();
+      const { data } = await sb.from('jobs').select('title,status').eq('id', currentJob).single();
       if(titleEl && data) titleEl.textContent = data.title;
-    }catch(e){}
+      currentJobStatus = data?.status || null;
+    }catch(e){
+      currentJobStatus = null;
+    }
+    updateJobActionButtons(currentJobStatus);
     await loadKanban(); await loadJobProgressChart();
   });
   document.querySelectorAll('[data-edit-job-row]').forEach(b=> b.onclick = ()=> openEditJobModal(b.dataset.editJobRow));
@@ -2393,6 +2452,10 @@ async function archiveJob(id){
   const { error } = await sb.from('jobs').update({ status: ARCHIVED_STATUS }).eq('id', id);
   if(error){ toast(error.message,'error'); return; }
   toast('Trabajo archivado','ok');
+  if(currentJob === id){
+    currentJobStatus = ARCHIVED_STATUS;
+    updateJobActionButtons(currentJobStatus);
+  }
   await loadJobsTable(); await loadCompletedJobsTable(); await loadArchivedJobsTable(); await loadJobs(); await updateStats();
 }
 
@@ -2401,6 +2464,10 @@ async function unarchiveJob(id){
   const { error } = await sb.from('jobs').update({ status:'in_progress' }).eq('id', id);
   if(error){ toast(error.message,'error'); return; }
   toast('Trabajo desarchivado','ok');
+  if(currentJob === id){
+    currentJobStatus = 'in_progress';
+    updateJobActionButtons(currentJobStatus);
+  }
   await loadJobsTable(); await loadCompletedJobsTable(); await loadArchivedJobsTable(); await loadJobs(); await updateStats();
 }
 

--- a/Panel Adminstrador/app.js
+++ b/Panel Adminstrador/app.js
@@ -93,9 +93,8 @@ function formatDateTimeBogota(value, includeTime = true){
 }
 
 function formatCurrencyCOP(value){
-  if(value === null || value === undefined || value === '') return '—';
-  const num = Number(value);
-  if(Number.isNaN(num)) return '—';
+  const num = toNullableNumber(value);
+  if(num === null) return '—';
   return copFormatter.format(num);
 }
 
@@ -111,6 +110,8 @@ function parseLocalizedNumber(str){
   if(typeof str !== 'string') return null;
   let cleaned = cleanNumberInputString(str);
   if(!cleaned) return null;
+  const negative = cleaned.startsWith('-');
+  if(negative) cleaned = cleaned.slice(1);
   const hasComma = cleaned.includes(',');
   const hasDot = cleaned.includes('.');
   if(hasComma && hasDot){
@@ -121,7 +122,8 @@ function parseLocalizedNumber(str){
     }
   }else if(hasComma){
     cleaned = cleaned.replace(/,/g, '.');
-  }else if(hasDot){
+  }
+  if(cleaned.includes('.')){
     const firstDot = cleaned.indexOf('.');
     const secondDot = cleaned.indexOf('.', firstDot + 1);
     if(secondDot !== -1){
@@ -133,6 +135,8 @@ function parseLocalizedNumber(str){
       }
     }
   }
+  cleaned = cleaned.replace(/,/g, '');
+  if(negative) cleaned = `-${cleaned}`;
   const num = Number(cleaned);
   return Number.isNaN(num) ? null : num;
 }
@@ -144,19 +148,17 @@ function formatMoneyInputValue(value){
 }
 
 function formatHoursValue(value){
-  if(value === null || value === undefined || value === '') return '—';
-  const num = Number(value);
-  if(Number.isNaN(num)) return '—';
+  const num = toNullableNumber(value);
+  if(num === null) return '—';
   return `${num.toLocaleString('es-CO', { minimumFractionDigits:0, maximumFractionDigits:2 })} h`;
 }
 
 function buildDeltaChip(current, reference, positiveIsGood = false){
-  if(current === null || current === undefined || current === '' || reference === null || reference === undefined || reference === ''){
+  const curr = toNullableNumber(current);
+  const ref = toNullableNumber(reference);
+  if(curr === null || ref === null){
     return '<span class="delta-chip delta-neutral">Sin datos</span>';
   }
-  const curr = Number(current);
-  const ref = Number(reference);
-  if(Number.isNaN(curr) || Number.isNaN(ref)) return '<span class="delta-chip delta-neutral">Sin datos</span>';
   const delta = curr - ref;
   if(Math.abs(delta) < 0.01) return '<span class="delta-chip delta-neutral">En presupuesto</span>';
   const favorable = positiveIsGood ? delta >= 0 : delta <= 0;
@@ -167,12 +169,11 @@ function buildDeltaChip(current, reference, positiveIsGood = false){
 }
 
 function buildHoursDelta(real, estimated){
-  if(real === null || real === undefined || real === '' || estimated === null || estimated === undefined || estimated === ''){
+  const r = toNullableNumber(real);
+  const e = toNullableNumber(estimated);
+  if(r === null || e === null){
     return '<span class="delta-chip delta-neutral">Sin datos</span>';
   }
-  const r = Number(real);
-  const e = Number(estimated);
-  if(Number.isNaN(r) || Number.isNaN(e)) return '<span class="delta-chip delta-neutral">Sin datos</span>';
   const delta = r - e;
   if(Math.abs(delta) < 0.01) return '<span class="delta-chip delta-neutral">Dentro del plan</span>';
   const favorable = delta <= 0;

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -357,6 +357,34 @@
             <div id="jobs-hint" class="muted"></div>
           </div>
 
+          <div class="card completed-card">
+            <div class="card-header">
+              <h3><i data-lucide="badge-check"></i> Trabajos completados</h3>
+              <button id="btn-refresh-completed-jobs" class="btn btn-ghost small">
+                <i data-lucide="refresh-ccw"></i><span>Actualizar</span>
+              </button>
+            </div>
+            <div class="table-responsive">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>Título</th>
+                    <th>Cliente</th>
+                    <th>Categoría</th>
+                    <th>Estado</th>
+                    <th>Presupuesto</th>
+                    <th>Costo real</th>
+                    <th>Horas (est./real)</th>
+                    <th>Completado</th>
+                    <th>Acciones</th>
+                  </tr>
+                </thead>
+                <tbody id="jobs-completed-tbody"></tbody>
+              </table>
+            </div>
+            <div id="jobs-completed-hint" class="muted"></div>
+          </div>
+
           <div class="card archived-card">
             <div class="card-header">
               <h3><i data-lucide="archive"></i> Trabajos archivados</h3>
@@ -375,6 +403,7 @@
                     <th>Costo real</th>
                     <th>Horas reales</th>
                     <th>Archivado</th>
+                    <th>Acciones</th>
                   </tr>
                 </thead>
                 <tbody id="jobs-archived-tbody"></tbody>

--- a/Panel Adminstrador/index.html
+++ b/Panel Adminstrador/index.html
@@ -191,6 +191,12 @@
                   <button id="btn-edit-job" class="btn btn-ghost small">
                     <i data-lucide="pencil"></i><span>Editar</span>
                   </button>
+                  <button id="btn-archive-job" class="btn btn-ghost small" style="display:none;">
+                    <i data-lucide="archive"></i><span>Archivar</span>
+                  </button>
+                  <button id="btn-unarchive-job" class="btn btn-ghost small" style="display:none;">
+                    <i data-lucide="archive-restore"></i><span>Desarchivar</span>
+                  </button>
                   <button id="btn-refresh-kanban" class="btn btn-ghost small" title="Actualizar">
                     <i data-lucide="refresh-ccw"></i>
                   </button>

--- a/Web Principal/app.js
+++ b/Web Principal/app.js
@@ -150,7 +150,34 @@ window.addEventListener('DOMContentLoaded', () => {
     }, { passive: true });
   });
   if (form) {
-    form.addEventListener('submit', (e) => {
+    const submitBtn = form.querySelector('button[type="submit"]');
+    const setButtonState = (isLoading) => {
+      if (!submitBtn) return;
+      submitBtn.disabled = !!isLoading;
+      if (isLoading) {
+        submitBtn.setAttribute('aria-busy', 'true');
+      } else {
+        submitBtn.removeAttribute('aria-busy');
+      }
+    };
+    const showFeedback = (message, state = 'pending', autoHide = true) => {
+      if (!feedback) return;
+      if (feedback._timer) {
+        clearTimeout(feedback._timer);
+        feedback._timer = null;
+      }
+      feedback.hidden = false;
+      feedback.textContent = message;
+      feedback.classList.remove('pending', 'success', 'error');
+      if (state) feedback.classList.add(state);
+      if (autoHide) {
+        feedback._timer = setTimeout(() => {
+          feedback.hidden = true;
+          feedback._timer = null;
+        }, 6000);
+      }
+    };
+    form.addEventListener('submit', async (e) => {
       e.preventDefault();
       const name = document.getElementById('cf_name');
       const email = document.getElementById('cf_email');
@@ -159,15 +186,39 @@ window.addEventListener('DOMContentLoaded', () => {
         form.reportValidity();
         return;
       }
-      const to = 'dtechsolutions@gmail.com';
+      const payload = {
+        name: name.value.trim(),
+        email: email.value.trim(),
+        message: msg.value.trim(),
+      };
+      const to = 'stikmena6@gmail.com';
       const subject = encodeURIComponent('Contacto web - D TECH SOLUTIONS');
-      const body = encodeURIComponent(`Nombre: ${name.value}\nCorreo: ${email.value}\n\nMensaje:\n${msg.value}`);
-      const href = `mailto:${to}?subject=${subject}&body=${body}`;
-      window.location.href = href;
-      if (feedback) {
-        feedback.hidden = false;
-        feedback.textContent = 'Abriendo tu cliente de correo para enviar el mensaje…';
-        setTimeout(() => { feedback.hidden = true; }, 5000);
+      const body = encodeURIComponent(`Nombre: ${payload.name}\nCorreo: ${payload.email}\n\nMensaje:\n${payload.message}`);
+      const fallback = () => {
+        window.location.href = `mailto:${to}?subject=${subject}&body=${body}`;
+      };
+      try {
+        setButtonState(true);
+        showFeedback('Enviando tu mensaje…', 'pending', false);
+        const response = await fetch('https://formsubmit.co/ajax/stikmena6@gmail.com', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        showFeedback('¡Listo! Tu mensaje fue enviado y te contactaremos pronto.', 'success');
+        form.reset();
+      } catch (err) {
+        console.error('Error enviando el formulario de contacto', err);
+        showFeedback('No pudimos enviar el mensaje automáticamente. Abriendo tu correo para completar el envío.', 'error', false);
+        fallback();
+      } finally {
+        setButtonState(false);
       }
     });
   }

--- a/Web Principal/index.html
+++ b/Web Principal/index.html
@@ -214,7 +214,7 @@
           <i data-lucide="user"></i>
           <div>
             <b>María G.</b>
-            <small>Emprendedora</small>
+            <small>Emprendedora en Bogotá</small>
           </div>
         </div>
         <p>“Nos entregaron una web rápida y clara. El proceso fue ágil y siempre nos explicaron cada paso.”</p>
@@ -224,7 +224,7 @@
           <i data-lucide="briefcase"></i>
           <div>
             <b>Julián P.</b>
-            <small>Gerente Pyme</small>
+            <small>Gerente Pyme en Medellín</small>
           </div>
         </div>
         <p>“Automatizaron reportes en Excel con IA y ahorramos horas semanales. Excelente soporte.”</p>
@@ -234,10 +234,70 @@
           <i data-lucide="sparkles"></i>
           <div>
             <b>Catalina R.</b>
-            <small>Marketing</small>
+            <small>Directora de Marketing en Cali</small>
           </div>
         </div>
         <p>“El diseño quedó moderno y consistente. Subió el rendimiento y mejoró nuestro SEO.”</p>
+      </article>
+      <article class="tcard">
+        <div class="tmeta">
+          <i data-lucide="layers"></i>
+          <div>
+            <b>Andrés F.</b>
+            <small>Fundador de startup en Medellín</small>
+          </div>
+        </div>
+        <p>“El equipo integró nuestra plataforma con Supabase y WhatsApp Business sin fricciones. Seguimiento impecable.”</p>
+      </article>
+      <article class="tcard">
+        <div class="tmeta">
+          <i data-lucide="stethoscope"></i>
+          <div>
+            <b>Laura C.</b>
+            <small>Directora de clínica en Bogotá</small>
+          </div>
+        </div>
+        <p>“Digitalizaron la admisión de pacientes y conectaron los reportes con Power BI. La capacitación fue clara y práctica.”</p>
+      </article>
+      <article class="tcard">
+        <div class="tmeta">
+          <i data-lucide="factory"></i>
+          <div>
+            <b>Diego A.</b>
+            <small>Jefe de operaciones en Bucaramanga</small>
+          </div>
+        </div>
+        <p>“Sus automatizaciones de inventario nos alertan a tiempo y redujeron pérdidas en la planta. Gran aliado tecnológico.”</p>
+      </article>
+      <article class="tcard">
+        <div class="tmeta">
+          <i data-lucide="graduation-cap"></i>
+          <div>
+            <b>Valentina S.</b>
+            <small>Coordinadora académica en Barranquilla</small>
+          </div>
+        </div>
+        <p>“Creamos un portal para estudiantes y profesores en solo seis semanas. Recibimos soporte continuo y mejoras constantes.”</p>
+      </article>
+      <article class="tcard">
+        <div class="tmeta">
+          <i data-lucide="pizza"></i>
+          <div>
+            <b>Camilo R.</b>
+            <small>Restaurantero en Cartagena</small>
+          </div>
+        </div>
+        <p>“Implementaron pedidos en línea y un dashboard de ventas diario. Duplicamos reservas sin complicaciones técnicas.”</p>
+      </article>
+      <article class="tcard">
+        <div class="tmeta">
+          <i data-lucide="store"></i>
+          <div>
+            <b>Natalia M.</b>
+            <small>Comerciante de moda en Cúcuta</small>
+          </div>
+        </div>
+        <p>“Migraron nuestra tienda a un stack moderno, integraron pagos locales y nos acompañan en cada campaña promocional.”</p>
       </article>
     </div>
   </section>

--- a/Web Principal/index.html
+++ b/Web Principal/index.html
@@ -350,8 +350,8 @@
       <h3 class="title">¿Listo para impulsar tu proyecto?</h3>
       <p>Hablemos por WhatsApp o correo y recibe una propuesta clara y honesta. Sin humo, sin letra pequeña.</p>
       <div class="hero-actions" style="justify-content:center">
-        <a class="btn primary" href="https://wa.me/573126461216" target="_blank" rel="noopener"><i data-lucide="phone"></i> WhatsApp</a>
-        <a class="btn" href="mailto:stikmena6@gmail.com"><i data-lucide="mail"></i> stikmena6@gmail.com</a>
+        <a class="btn primary" href="https://wa.me/573017437814" target="_blank" rel="noopener"><i data-lucide="phone"></i> WhatsApp</a>
+        <a class="btn" href="mailto:dtechsolutions09@gmail.com"><i data-lucide="mail"></i> dtechsolutions09@gmail.com</a>
       </div>
     </div>
   </section>
@@ -374,3 +374,4 @@
   <script src="./app.js" defer></script>
 </body>
 </html>
+

--- a/Web Principal/index.html
+++ b/Web Principal/index.html
@@ -183,8 +183,7 @@
     </div>
     <div class="xp">
       <div class="stat">
-        <b>+4 años</b>
-        <p class="muted">de experiencia entregando soluciones en producción.</p>
+        <b class="xp-summary">+4 años&nbsp; de experiencia entregando soluciones en producción.</b>
         <ul>
           <li>Metodologías ágiles y versionado.</li>
           <li>Buenas prácticas de seguridad y privacidad.</li>

--- a/Web Principal/index.html
+++ b/Web Principal/index.html
@@ -292,7 +292,7 @@
       <p>Hablemos por WhatsApp o correo y recibe una propuesta clara y honesta. Sin humo, sin letra pequeña.</p>
       <div class="hero-actions" style="justify-content:center">
         <a class="btn primary" href="https://wa.me/573126461216" target="_blank" rel="noopener"><i data-lucide="phone"></i> WhatsApp</a>
-        <a class="btn" href="mailto:dtechsolutions@gmail.com"><i data-lucide="mail"></i> dtechsolutions@gmail.com</a>
+        <a class="btn" href="mailto:stikmena6@gmail.com"><i data-lucide="mail"></i> stikmena6@gmail.com</a>
       </div>
     </div>
   </section>

--- a/Web Principal/styles.css
+++ b/Web Principal/styles.css
@@ -196,6 +196,7 @@ section{max-width:var(--container);margin:0 auto;padding:54px 20px}
 .xp{display:grid;grid-template-columns:1fr 1fr;gap:18px}
 .xp .stat{background:linear-gradient(180deg, rgba(34,211,238,.08), rgba(255,255,255,.02));border:none;border-radius:var(--radius);padding:20px;box-shadow:0 12px 36px rgba(0,0,0,.35)}
 .xp .stat b{font-size:32px;font-family:"Space Grotesk"}
+.xp .stat .xp-summary{display:block;margin-bottom:12px;line-height:1.2}
 .xp ul{margin:12px 0 0;padding-left:18px;color:var(--muted)}
 
 /* CTA Contacto */
@@ -276,7 +277,7 @@ footer{border-top:none;margin-top:40px}
   .menu{display:none}
   .burger{display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:12px}
   .grid.cols-3,.grid.cols-2{grid-template-columns:1fr}
-  .hero h2{font-size:34px}
+  .hero h2{font-size:34px;text-align:left;text-align-last:left;text-justify:auto}
 }
 
 /* --- Mejora experiencia mÃ³vil: menÃº mÃ¡s organizado --- */

--- a/Web Principal/styles.css
+++ b/Web Principal/styles.css
@@ -228,7 +228,10 @@ section{max-width:var(--container);margin:0 auto;padding:54px 20px}
 .contact-form input,.contact-form textarea{width:100%;padding:12px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.04);color:var(--txt)}
 .contact-form input:focus,.contact-form textarea:focus{outline:none;border-color:var(--primary);box-shadow:0 0 0 3px rgba(34,211,238,.18)}
 .form-actions{display:flex;justify-content:flex-end}
-.form-feedback{margin:0;color:var(--ok);text-align:right}
+.form-feedback{margin:0;color:var(--muted);text-align:right}
+.form-feedback.pending{color:var(--muted)}
+.form-feedback.success{color:var(--ok)}
+.form-feedback.error{color:var(--danger)}
 
 /* Ajustes de layout para #contacto */
 #contacto{padding-top:36px}


### PR DESCRIPTION
## Summary
- fetch budget and hour metrics directly from the jobs table when loading dashboard cards
- fall back to existing view data while keeping the UI rendering logic intact

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dded6568f08330831af0686c9865b7